### PR TITLE
Add tileMargin option

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -27,7 +27,8 @@ Example::
       "maxSize": 2048,
       "pbfAlias": "pbf",
       "serveAllFonts": false,
-      "serveStaticMaps": true
+      "serveStaticMaps": true,
+      "tileMargin": 0
     },
     "styles": {
       "basic": {

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -96,6 +96,13 @@ Maximum image side length to be allowed to be rendered (including scale factor).
 Be careful when changing this value since there are hardware limits that need to be considered.
 Default is ``2048``.
 
+``tileMargin``
+--------------
+
+Additional image side length added during tile rendering that is cropped from the delivered tile. This is useful for resolving the issue with cropped labels, 
+but it does come with a performance degradation, because additional, adjacent vector tiles need to be loaded to genenrate a single tile.
+Default is ``0`` to disable this processing. 
+
 ``minRendererPoolSizes``
 ------------------------
 

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -407,6 +407,13 @@ module.exports = function(options, repo, params, id, publicUrl, dataResolver) {
         params.width *= 2;
         params.height *= 2;
       }
+      
+      var tileMargin = Math.max(options.tileMargin || 0, 0);
+      if (z > 2 && tileMargin > 0) {
+        params.width += tileMargin * 2 * scale;
+        params.height += tileMargin * 2 * scale;
+      }
+
       renderer.render(params, function(err, data) {
         pool.release(renderer);
         if (err) {
@@ -421,6 +428,10 @@ module.exports = function(options, repo, params, id, publicUrl, dataResolver) {
             channels: 4
           }
         });
+        
+        if (z > 2 && tileMargin > 0) {
+            image.extract({ left: tileMargin * scale, top: tileMargin * scale, width: width * scale, height: height * scale });
+        }
 
         if (z == 0) {
           // HACK: when serving zoom 0, resize the 0 tile from 512 to 256


### PR DESCRIPTION
The issue of cropped labels in raster tiles has been reported in multiple times: #344, #184, #35 #224, etc. I have tried a variety of offered suggestions to resolve the issue, but none worked reliably. 

I ended up solving the problem by adding code to generate larger tiles and then crop them to the right size. This can be controlled via a new `"tileMargin"` option in configuration file.

Maybe this will be useful to someone else.

