### PR TITLE
Relax Node.js compatibility for -light version

### DIFF
--- a/publish.js
+++ b/publish.js
@@ -28,6 +28,8 @@ delete packageJson.dependencies['sharp'];
 delete packageJson.optionalDependencies;
 delete packageJson.devDependencies;
 
+packageJson.engines.node = '>= 10';
+
 var str = JSON.stringify(packageJson, undefined, 2);
 fs.writeFileSync('light/package.json', str);
 fs.renameSync('light/README_light.md', 'light/README.md');


### PR DESCRIPTION
Hello!

`tileserver-gl-light` works perfectly with Node.js 12 and 13.
This PR relax the field `engines.node` in its `package.json` file.

We actually use a `tileserver-gl-light` fork in French governement digital services, with this improvement :)

Jerome