### PR TITLE
Close connection on erros

### DIFF
--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -424,7 +424,7 @@ module.exports = (options, repo, params, id, publicUrl, dataResolver) => {
         pool.release(renderer);
         if (err) {
           console.error(err);
-          return;
+          return res.status(500).send(err);
         }
 
         const image = sharp(data, {


### PR DESCRIPTION
This is necessary for tileserver to close a connection immediatly on render errors instead of waiting for a timeout in the client. I believe that problem is as at least related to the already closed issue #171.