### PR TITLE
FIx issue #350 Semi-transparent outlines on raw, premultiplied input

### DIFF
--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -427,6 +427,22 @@ module.exports = (options, repo, params, id, publicUrl, dataResolver) => {
           return;
         }
 
+        // Fix semi-transparent outlines on raw, premultiplied input
+        // https://github.com/klokantech/tileserver-gl/issues/350#issuecomment-477857040
+        for (var i = 0; i < data.length; i += 4) {
+          var alpha = data[i + 3];
+          var norm = alpha / 255;
+          if (alpha === 0) {
+            data[i] = 0;
+            data[i + 1] = 0;
+            data[i + 2] = 0;
+          } else {
+            data[i] = data[i] / norm;
+            data[i + 1] = data[i + 1] / norm;
+            data[i + 2] = data[i + 2] / norm;
+          }
+        }
+
         const image = sharp(data, {
           raw: {
             width: params.width * scale,


### PR DESCRIPTION
I'm not sure if there is any other reason why this longstanding issue is not resolved yet. But I figured a pull request with a properly indented fix could help, so here it is. This fixes issue #350.