### PR TITLE
update glyph-pbf-composite

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "docker": "docker build -f Dockerfile . && docker run --rm -i -p 8080:80 $(docker build -q .)"
   },
   "dependencies": {
+    "@mapbox/glyph-pbf-composite": "0.0.3",
     "@mapbox/mapbox-gl-native": "5.0.2",
     "@mapbox/mapbox-gl-style-spec": "13.9.1",
     "@mapbox/mbtiles": "0.11.0",
@@ -31,7 +32,6 @@
     "cors": "2.8.5",
     "esm": "3.2.25",
     "express": "4.17.1",
-    "glyph-pbf-composite": "0.0.2",
     "handlebars": "4.5.3",
     "http-shutdown": "1.2.1",
     "morgan": "1.9.1",

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,7 +4,7 @@ const path = require('path');
 const fs = require('fs');
 
 const clone = require('clone');
-const glyphCompose = require('glyph-pbf-composite');
+const glyphCompose = require('@mapbox/glyph-pbf-composite');
 
 
 module.exports.getPublicUrl = (publicUrl, req) => publicUrl || `${req.protocol}://${req.headers.host}/`;


### PR DESCRIPTION
glyph-pbf-composite v0.0.2 were released without license that can be issue of licensing complience
as license were added in v0.0.3 NPM release it nice to be updated to licensed software version