### PR TITLE
add option to pass npm publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Alternatively, you can use the `tileserver-gl-light` package instead, which is p
 
 ## Using Docker
 
-An alternative to npm to start the packed software easier is to install [Docker](http://www.docker.com/) on your computer and then run in the directory with the downloaded MBTiles the command:
+An alternative to npm to start the packed software easier is to install [Docker](https://www.docker.com/) on your computer and then run in the directory with the downloaded MBTiles the command:
 
 ```bash
 docker run --rm -it -v $(pwd):/data -p 8080:80 klokantech/tileserver-gl
@@ -45,4 +45,4 @@ On laptop you can use [Docker Kitematic](https://kitematic.com/) and search "til
 
 ## Documentation
 
-You can read full documentation of this project at http://tileserver.readthedocs.io/.
+You can read full documentation of this project at https://tileserver.readthedocs.io/.

--- a/README_light.md
+++ b/README_light.md
@@ -11,7 +11,25 @@ Then you can simply run `tileserver-gl-light zurich_switzerland.mbtiles` to star
 
 See also `tileserver-gl` which contains server side rendering.
 
-Prepared vector tiles can be downloaded from [OpenMapTiles](https://openmaptiles.org/downloads/).
+Prepared vector tiles can be downloaded from [OpenMapTiles.com](https://openmaptiles.com/downloads/planet/).
+
+## Building docker image
+
+You can build TileServer GL light image from source.
+
+```
+git clone https://github.com/maptiler/tileserver-gl.git
+cd tileserver-gl
+node publish.js --no-publish
+cd light
+docker build -t tileserver-gl-light .
+```
+
+[Download from OpenMapTiles.com](https://openmaptiles.com/downloads/planet/) or [create](https://github.com/openmaptiles/openmaptiles) your vector tile, and run following in directory contains your *.mbtiles.
+
+```
+docker run --rm -it -v $(pwd):/data -p 8000:80 tileserver-gl-light
+```
 
 ## Documentation
-You can read full documentation of this project at http://tileserver.readthedocs.io/.
+You can read full documentation of this project at https://tileserver.readthedocs.io/.

--- a/publish.js
+++ b/publish.js
@@ -35,6 +35,11 @@ fs.writeFileSync('light/package.json', str);
 fs.renameSync('light/README_light.md', 'light/README.md');
 fs.renameSync('light/Dockerfile_light', 'light/Dockerfile');
 
+// for Build tileserver-gl-light docker image, don't publish
+if (process.argv.length > 2 && process.argv[2] == "--no-publish") {
+  process.exit(0)
+}
+
 /* PUBLISH */
 
 // tileserver-gl


### PR DESCRIPTION
I want to build tileserver-gl-light for arm (Raspberry Pi) but I don't run npm publish from publish.js.
I make `--no-publish` option to make only tileserver-gl-light.

I do following:
```
node publish.js --no-publish
cd light
docker buildx build -t tileserver-gl-light:latest --platform linux/amd64,linux/arm/v7 .
```