### PR TITLE
[WIP] Support tilejson proxy for remote tile provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@mapbox/mapbox-gl-native": "5.0.2",
     "@mapbox/mapbox-gl-style-spec": "13.12.0",
     "@mapbox/mbtiles": "0.11.0",
+    "@mapbox/tilejson": "1.1.0",
     "@mapbox/sphericalmercator": "1.1.0",
     "@mapbox/vector-tile": "1.3.1",
     "advanced-pool": "0.3.3",

--- a/src/server.js
+++ b/src/server.js
@@ -160,7 +160,7 @@ function start(opts) {
             let mbtilesFile;
             for (const id of Object.keys(data)) {
               if (id === mbtiles) {
-                mbtilesFile = data[id].mbtiles;
+                mbtilesFile = data[id].mbtiles || data[id].remote_tilejson;
               }
             }
             return mbtilesFile;
@@ -190,8 +190,8 @@ function start(opts) {
 
   for (const id of Object.keys(data)) {
     const item = data[id];
-    if (!item.mbtiles || item.mbtiles.length === 0) {
-      console.log(`Missing "mbtiles" property for ${id}`);
+    if ((!item.mbtiles || item.mbtiles.length === 0) && (!item.remote_tilejson || item.remote_tilejson.length === 0)) {
+      console.log(`Missing "mbtiles" or "remote_tilejson" property for ${id}`);
       continue;
     }
 


### PR DESCRIPTION
The goal is to continue using tileserver-gl while the tile source is no more a mbtiles but a remote source described by a remote tilejson.

I done this in pursuing my goal to have a on demand tiles from OpenMapTiles. The remote tiles and tilesjson are here typically from postvers.

This PR add a remote tilejson to the data configuration:
```json
  "data": {
    "v3": {
      "remote_tilejson": "http://postserve:8090/",
      "tilejson": {
        "tiles": [
          "http://a.localhost:8080/openmaptiles/v3/{z}/{x}/{y}.pbf",
          "http://b.localhost:8080/openmaptiles/v3/{z}/{x}/{y}.pbf",
          "http://c.localhost:8080/openmaptiles/v3/{z}/{x}/{y}.pbf"
        ]
      }
    }
  }
```

It a proxy over the remote tilejson and add the ability to override some part.

This is a working prof of concept. I am not js developer, but I can improve this PR to make margeable if you wish to integrate this new concept.

cc @klokan @nyurik