### PR TITLE
Add id to tilejson

### DIFF
--- a/src/serve_data.js
+++ b/src/serve_data.js
@@ -145,6 +145,7 @@ module.exports = {
           Object.assign(tileJSON, info);
 
           tileJSON['tilejson'] = '2.0.0';
+          tileJSON['id'] = id;
           delete tileJSON['filesize'];
           delete tileJSON['mtime'];
           delete tileJSON['scheme'];

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -711,6 +711,7 @@ module.exports = {
     const tileJSON = {
       'tilejson': '2.0.0',
       'name': styleJSON.name,
+      'id': id,
       'attribution': '',
       'minzoom': 0,
       'maxzoom': 20,


### PR DESCRIPTION
Add the `id` field to tilejson output. So be able to retrieve the tilejson and rebuild the path to direct tilejson for further usage.

* On rendered it's on a add.
* On data it may override the id from the mbtiles.
