### PR TITLE
Fix preview thumbnail for raster data sources

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -362,7 +362,7 @@ function start(opts) {
       if (!data_.is_vector) {
         if (center) {
           const centerPx = mercator.px([center[0], center[1]], center[2]);
-          data_.thumbnail = `${center[2]}/${Math.floor(centerPx[0] / 256)}/${Math.floor(centerPx[1] / 256)}.${data_.format}`;
+          data_.thumbnail = `${center[2]}/${Math.floor(centerPx[0] / 256)}/${Math.floor(centerPx[1] / 256)}.${data_.tileJSON.format}`;
         }
 
         data_.xyz_link = utils.getTileUrls(


### PR DESCRIPTION
The data sources structure was changed in the 'dynamic_styles' branch introducing a tileJSON object. Adapt the code filling the preview template to the change to get the correct file format instead of "undefined".

See also f2dc13e.

Fix #440 Preview thumbnail missing for raster data source -- file suffix "undefined"