### PR TITLE
Ensure valid style directory reference

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -118,7 +118,7 @@ const startWithMBTiles = (mbtilesFile) => {
       }
       const bounds = info.bounds;
 
-      const styleDir = path.resolve(__dirname, "../node_modules/tileserver-gl-styles/");
+      const styleDir = path.dirname(require.resolve('tileserver-gl-styles/package.json'));
 
       const config = {
         "options": {


### PR DESCRIPTION
# Pull Request

There is currently an issue with the package if it is installed locally and executed from a sub shell or directory. The style directory of the `tileserver-gl-styles` module won't be correctly resolved. By using the underlying node module resolution rather than relative paths a valid reference is ensured.

## Error
<img width="329" alt="Screenshot 2020-06-06 at 19 42 41" src="https://user-images.githubusercontent.com/1060490/83950856-f96ebc00-a82d-11ea-8d92-3a60be4eea78.png">

