### PR TITLE
Remove max node version restriction

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "license": "BSD-2-Clause",
   "engines": {
-    "node": ">=10 <11"
+    "node": ">=10"
   },
   "scripts": {
     "test": "mocha test/**.js --timeout 10000",


### PR DESCRIPTION
# Pull Request

The module is currently restricting the node version through an upper bound of `11.X`. Since the [the latest LTS version is 12.X](https://nodejs.org/en/blog/release/v12.13.0) and works fine with the code, this PR removes the the max. node version.