### PR TITLE
Add "serveAllData" option

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -28,6 +28,7 @@ Example::
       "pbfAlias": "pbf",
       "serveAllFonts": false,
       "serveAllStyles": false,
+      "serveAllData": false,
       "serveStaticMaps": true,
       "tileMargin": 0
     },
@@ -131,6 +132,12 @@ Default is ``[16, 8, 4]``.
 If this option is enabled, all the styles from the ``paths.styles`` will be served. (No recursion, only ``.json`` files are used.)
 The process will also watch for changes in this directory and remove/add more styles dynamically.
 It is recommended to also use the ``serveAllFonts`` option when using this option.
+
+``serveAllData``
+------------------------
+
+Similar to ``serveAllStyles`` above, if this option is enabled, all the tiles from the ``paths.mbtiles`` will be served. (No recursion, only ``.mbtiles`` files are used.)
+The process will also watch for changes in this directory and remove/add more tiles dynamically.
 
 ``watermark``
 -----------

--- a/src/serve_data.js
+++ b/src/serve_data.js
@@ -117,6 +117,9 @@ module.exports = {
 
     return app;
   },
+  remove: (repo, id) => {
+    delete repo[id];
+  },
   add: (options, repo, params, id, publicUrl) => {
     const mbtilesFile = path.resolve(options.paths.mbtiles, params.mbtiles);
     let tileJSON = {

--- a/src/server.js
+++ b/src/server.js
@@ -230,10 +230,7 @@ function start(opts) {
           let id = path.basename(filename, '.mbtiles');
           console.log(`Data "${id}" changed, updating...`);
 
-          serve_style.remove(serving.styles, id);
-          if (serve_rendered) {
-            serve_rendered.remove(serving.rendered, id);
-          }
+          serve_data.remove(serving.data, id);
 
           if (eventType == "add" || eventType == "change") {
             let item = {


### PR DESCRIPTION
This is based on the `serveAllStyles` implementation in https://github.com/maptiler/tileserver-gl/commit/d7a34f3a74bf41de8343367bcefce2f0e0a06539. This does the same for the `mbtiles` directory.

@petrsloup maybe `serveAllTiles` is a better name for this option? I can't choose between the two.