### PR TITLE
Support local:// raster tile URLs

### DIFF
--- a/src/serve_style.js
+++ b/src/serve_style.js
@@ -40,6 +40,9 @@ module.exports = {
       for (const name of Object.keys(styleJSON_.sources)) {
         const source = styleJSON_.sources[name];
         source.url = fixUrl(req, source.url, item.publicUrl);
+        if (source.tiles) {
+          source.tiles = source.tiles.map(url => fixUrl(req, url, item.publicUrl))
+        }
       }
       // mapbox-gl-js viewer cannot handle sprite urls with query
       if (styleJSON_.sprite) {


### PR DESCRIPTION
In the style JSON configuration, allow to use the local:// pseudo-protocol prefix also for raster tile source URLs. When serving the style JSON, rewrite it into an absolute URL using the public URL or the Host header from the request.

This allows to use raster tile sources which are served from the same domain, but externally from tileserver-gl. The requests could be handled by a reverse proxy in front of tileserver-gl for example, and redirected to a different service or static files.

Instead of hardcoding an absolute host name in the style configuration, using a relative URL allows to use the same style configuration on different hosts and on localhost in the development environment.

----

My use case is that I want to combine an external raster tile source with vector tiles served by tileserver-gl into a “hybrid” style. The external raster tiles can be reached by an URL on the same host name. Their URLs are handled and redirected to a different service by the reverse proxy sitting in front of everything.

I would like to avoid to put the absolute URL into the style configuration, to be able to run the whole stack on a different host and also locally for development.