### PR TITLE
Streamline Dockerfile for caching and size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,6 @@
-.git
-docs/_build
-node_modules
-test_data
-light
-config.json
-*.mbtiles
+*
+!src
+!public
+!package.json
+!package-lock.json
+!run.sh

--- a/.dockerignore
+++ b/.dockerignore
@@ -3,4 +3,4 @@
 !public
 !package.json
 !package-lock.json
-!run.sh
+!docker-entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,8 +54,10 @@ ENV CHOKIDAR_INTERVAL=500
 VOLUME /data
 WORKDIR /data
 
-EXPOSE 80
+EXPOSE 8000
+
+USER node:node
 
 ENTRYPOINT ["/app/docker-entrypoint.sh"]
 
-CMD ["-p", "80"]
+CMD ["-p", "8000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,15 +13,11 @@ RUN export DEBIAN_FRONTEND=noninteractive \
       libgbm-dev \
       libllvm7 \
       libprotobuf-dev \
-      libxxf86vm-dev \
-      xvfb \
-      x11-utils \
   && apt-get -y --purge autoremove \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-#RUN mkdir -p /usr/src/app
-COPY / /usr/src/app
+COPY . /usr/src/app
 
 ENV NODE_ENV="production"
 
@@ -33,12 +29,8 @@ FROM node:10-buster-slim AS final
 RUN export DEBIAN_FRONTEND=noninteractive \
   && apt-get -qq update \
   && apt-get -y --no-install-recommends install \
-      curl \
-      libcairo2 \
       libgles2-mesa \
       libegl1 \
-      libprotobuf17 \
-      libxxf86vm1 \
       xvfb \
       xauth \
   && apt-get -y --purge autoremove \

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,12 +40,12 @@ RUN export DEBIAN_FRONTEND=noninteractive \
       libprotobuf17 \
       libxxf86vm1 \
       xvfb \
-      x11-utils \
+      xauth \
   && apt-get -y --purge autoremove \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /usr/src/app /usr/src/app
+COPY --from=builder /usr/src/app /app
 
 ENV NODE_ENV="production"
 ENV CHOKIDAR_USEPOLLING=1
@@ -56,4 +56,6 @@ WORKDIR /data
 
 EXPOSE 80
 
-ENTRYPOINT ["/usr/src/app/run.sh"]
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
+
+CMD ["-p", "80"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,59 @@
-FROM node:10-stretch
+FROM node:10-buster AS builder
+
+RUN export DEBIAN_FRONTEND=noninteractive \
+  && apt-get -qq update \
+  && apt-get -y --no-install-recommends install \
+      apt-transport-https \
+      curl \
+      unzip \
+      build-essential \
+      python \
+      libcairo2-dev \
+      libgles2-mesa-dev \
+      libgbm-dev \
+      libllvm7 \
+      libprotobuf-dev \
+      libxxf86vm-dev \
+      xvfb \
+      x11-utils \
+  && apt-get -y --purge autoremove \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+#RUN mkdir -p /usr/src/app
+COPY / /usr/src/app
+
+ENV NODE_ENV="production"
+
+RUN cd /usr/src/app && npm install --production
+
+
+FROM node:10-buster-slim AS final
+
+RUN export DEBIAN_FRONTEND=noninteractive \
+  && apt-get -qq update \
+  && apt-get -y --no-install-recommends install \
+      curl \
+      libcairo2 \
+      libgles2-mesa \
+      libegl1 \
+      libprotobuf17 \
+      libxxf86vm1 \
+      xvfb \
+      x11-utils \
+  && apt-get -y --purge autoremove \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /usr/src/app /usr/src/app
 
 ENV NODE_ENV="production"
 ENV CHOKIDAR_USEPOLLING=1
 ENV CHOKIDAR_INTERVAL=500
+
 VOLUME /data
 WORKDIR /data
+
 EXPOSE 80
-ENTRYPOINT ["/bin/bash", "/usr/src/app/run.sh"]
 
-RUN apt-get -qq update \
-&& DEBIAN_FRONTEND=noninteractive apt-get -y install \
-    apt-transport-https \
-    curl \
-    unzip \
-    build-essential \
-    python \
-    libcairo2-dev \
-    libgles2-mesa-dev \
-    libgbm-dev \
-    libllvm3.9 \
-    libprotobuf-dev \
-    libxxf86vm-dev \
-    xvfb \
-    x11-utils \
-&& apt-get clean
-
-RUN mkdir -p /usr/src/app
-COPY / /usr/src/app
-RUN cd /usr/src/app && npm install --production
+ENTRYPOINT ["/usr/src/app/run.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 
 if ! which -- "${1}"; then
   # first arg is not an executable
-  xvfb-run --server-args="-screen 0 1024x768x24" -- node /app/ "$@"
+  xvfb-run -a --server-args="-screen 0 1024x768x24" -- node /app/ "$@"
   exit $?
 fi
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+if ! which -- "${1}"; then
+  # first arg is not an executable
+  xvfb-run --server-args="-screen 0 1024x768x24" -- node /app/ "$@"
+  exit $?
+fi
+
+exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,10 +2,22 @@
 
 set -e
 
+handle() {
+	SIGNAL=$(( $? - 128 ))
+	echo "Caught signal ${SIGNAL}, stopping gracefully"
+	kill -s ${SIGNAL} $(pidof node) 2>/dev/null
+}
+
+trap handle INT TERM
+
 if ! which -- "${1}"; then
   # first arg is not an executable
-  xvfb-run -a --server-args="-screen 0 1024x768x24" -- node /app/ "$@"
-  exit $?
+  xvfb-run -a --server-args="-screen 0 1024x768x24" -- node /app/ "$@" &
+	# Wait exits immediately on signals which have traps set. Store return value and wait
+	# again for all jobs to actually complete before continuing.
+	wait $! || RETVAL=$?
+	wait
+	exit ${RETVAL}
 fi
 
 exec "$@"


### PR DESCRIPTION
Use newer base images and modify Dockerfile to allow for better caching and smaller image file size. Simplify entry script and run as a non-root user.