### PR TITLE
Fix missing ScaleDenominator in wmts.tmpl

### DIFF
--- a/public/templates/wmts.tmpl
+++ b/public/templates/wmts.tmpl
@@ -395,7 +395,7 @@
       </TileMatrix>
       <TileMatrix>
         <ows:Identifier>18</ows:Identifier>
-        <ScaleDenominator></ScaleDenominator>
+        <ScaleDenominator>1066.3647919249</ScaleDenominator>
         <TopLeftCorner>90 -180</TopLeftCorner>
         <TileWidth>256</TileWidth>
         <TileHeight>256</TileHeight>


### PR DESCRIPTION
The missing ScaleDenominator causes GeoServer to throw an error when importing the layer.