### PR TITLE
fix crash in serveAllFonts

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -136,7 +136,7 @@ function start(opts) {
             return dataItemId;
           } else {
             if (fromData || !allowMoreData) {
-              console.log(`ERROR: style "${file.name}" using unknown mbtiles "${mbtiles}"! Skipping...`);
+              console.log(`ERROR: style "${item.style}" using unknown mbtiles "${mbtiles}"! Skipping...`);
               return undefined;
             } else {
               let id = mbtiles.substr(0, mbtiles.lastIndexOf('.')) || mbtiles;


### PR DESCRIPTION
variable file does not exist. Backtrace

```
ReferenceError: file is not defined
  at serve_style.add (/usr/src/app/src/server.js:139:44)
  at Proxy.add (/usr/src/app/src/serve_style.js:115:28)
  at addStyle (/usr/src/app/src/server.js:121:31)
  at fs.readdir (/usr/src/app/src/server.js:215:11)
  at args (fs.js:140:20)
  at internal/util.js:370:14
  at getDirents (internal/fs/utils.js:149:7)
  at FSReqWrap.req.oncomplete (fs.js:775:7)
```