### PR TITLE
Add source style URLs in /styles.json

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -250,7 +250,8 @@ function start(opts) {
         version: styleJSON.version,
         name: styleJSON.name,
         id: id,
-        url: `${utils.getPublicUrl(opts.publicUrl, req)}styles/${id}/style.json${query}`
+        url: `${utils.getPublicUrl(opts.publicUrl, req)}styles/${id}/style.json${query}`,
+        'source:url': styleJSON.metadata ? styleJSON.metadata['openmaptiles:mapbox:source:url'] : undefined,
       });
     }
     res.send(result);


### PR DESCRIPTION
The goal is to share the URL of the style source code to easy discovery and so contribution : idea, issues, PR...

There is already a property for the source code of the style as `openmaptiles:mapbox:source:url`. But for now containing mostly `mapbox://...`.

I will also suggest using right value to style pointing to the github project of the style.

I chose to expose the URL in the `source:url` property, maybe not the best move.

The link to style source code can be then show in the home page or other tools using the tileserver-gl API.