### PR TITLE
Render up to scale level 22

### DIFF
--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -375,7 +375,7 @@ module.exports = {
         scale = getScale(req.params.scale),
         format = req.params.format;
       if (z < 0 || x < 0 || y < 0 ||
-        z > 20 || x >= Math.pow(2, z) || y >= Math.pow(2, z)) {
+        z > 22 || x >= Math.pow(2, z) || y >= Math.pow(2, z)) {
         return res.status(404).send('Out of bounds');
       }
       const tileSize = 256;


### PR DESCRIPTION
For detailed city rendering we need to render rasterfiles up to and including level 21. Therefore I propose to change the maximum raster level to 22