### PR TITLE
update sharp to avoid segfault

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "pbf": "3.2.1",
     "proj4": "2.6.0",
     "request": "2.88.2",
-    "sharp": "0.25.1",
+    "sharp": "0.26.2",
     "tileserver-gl-styles": "2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Before https://github.com/lovell/sharp/commit/e82a585cec48fa7a16e4edcccb1ef9021e27d2ca the server may crash with a segfault when under high load.

---

When testing with https://github.com/tsenart/vegeta found that the server would crash with a segfault in sharp/libvips. Narrowed the issue down to the commit referenced above.

Any version of sharp >=v0.25.2 resolves the problem.

Verified the issue and fix using the project's Dockerfile.

Command used for testing:
`echo 'GET http://localhost:8080/styles/basic-preview/14/8581/5738@2x.png' | vegeta attack -rate 50/s | vegeta report`