### PR TITLE
Open mbtiles in readonly mode

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -103,7 +103,7 @@ const startWithMBTiles = (mbtilesFile) => {
     console.log(`ERROR: Not valid MBTiles file: ${mbtilesFile}`);
     process.exit(1);
   }
-  const instance = new MBTiles(mbtilesFile, (err) => {
+  const instance = new MBTiles(mbtilesFile + '?mode=ro', (err) => {
     if (err) {
       console.log('ERROR: Unable to open MBTiles.');
       console.log(`       Make sure ${path.basename(mbtilesFile)} is valid MBTiles.`);

--- a/src/serve_data.js
+++ b/src/serve_data.js
@@ -129,7 +129,7 @@ module.exports = {
     }
     let source;
     const sourceInfoPromise = new Promise((resolve, reject) => {
-      source = new MBTiles(mbtilesFile, err => {
+      source = new MBTiles(mbtilesFile + '?mode=ro', err => {
         if (err) {
           reject(err);
           return;

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -764,7 +764,7 @@ module.exports = {
           if (!mbtilesFileStats.isFile() || mbtilesFileStats.size === 0) {
             throw Error(`Not valid MBTiles file: ${mbtilesFile}`);
           }
-          map.sources[name] = new MBTiles(mbtilesFile, err => {
+          map.sources[name] = new MBTiles(mbtilesFile + '?mode=ro', err => {
             map.sources[name].getInfo((err, info) => {
               if (err) {
                 console.error(err);


### PR DESCRIPTION
Open mbtiles in readonly mode as tileserver-gl never writes to them.
I'm not sure if there are any real benefits to this, but I figured it can't hurt.