### PR TITLE
Use center and zoom from style json

### DIFF
--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -1375,7 +1375,7 @@ export const serve_rendered = {
     };
     const attributionOverride = params.tilejson && params.tilejson.attribution;
     if (styleJSON.center && styleJSON.zoom) {
-      tileJSON.center = styleJSON.center.concat(styleJSON.zoom);
+      tileJSON.center = styleJSON.center.concat(Math.round(styleJSON.zoom));
     }
     Object.assign(tileJSON, params.tilejson || {});
     tileJSON.tiles = params.domains || options.domains;

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -1374,6 +1374,9 @@ export const serve_rendered = {
       type: 'baselayer',
     };
     const attributionOverride = params.tilejson && params.tilejson.attribution;
+    if (styleJSON.center && styleJSON.zoom) {
+      tileJSON.center = styleJSON.center.concat(styleJSON.zoom);
+    }
     Object.assign(tileJSON, params.tilejson || {});
     tileJSON.tiles = params.domains || options.domains;
     fixTileJSONCenter(tileJSON);


### PR DESCRIPTION
Use the center and zoom values from the style json as default for the center in the tilejson of the rendered map. This is especially useful for serveAllStyles where there is no other way to set this values explicitly.