### PR TITLE
fix blocking of tileserver while serving index

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -330,7 +330,7 @@ function start(opts) {
   };
 
   serveTemplate('/$', 'index', req => {
-    const styles = clone(serving.styles || {});
+    const styles = Object.assign({}, serving.styles || {}, {});
     for (const id of Object.keys(styles)) {
       const style = styles[id];
       style.name = (serving.styles[id] || serving.rendered[id] || {}).name;
@@ -350,7 +350,7 @@ function start(opts) {
           `styles/${id}`, style.serving_rendered.tileJSON.format, opts.publicUrl)[0];
       }
     }
-    const data = clone(serving.data || {});
+    const data = Object.assign({}, serving.data || {}, {});
     for (const id of Object.keys(data)) {
       const data_ = data[id];
       const tilejson = data[id].tileJSON;


### PR DESCRIPTION
we noticed sporadic long blocks of the entier tileserver on version 3.1.1
They always happend when somebody accessed the frontPage.
Our guess is, that clone() blocks the object and takes very long to finish.

We replaced the clone with ES6 magic from https://stackoverflow.com/a/42988763
and the problem is gone.

Also the time to generate the index goes from ~3s to ~0.2s
This should primarily affect user with many large styles