### PR TITLE
Fix xss due to handlebars variables in javascript

### DIFF
--- a/public/templates/data.tmpl
+++ b/public/templates/data.tmpl
@@ -5,10 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{{name}} - TileServer GL</title>
   {{#is_vector}}
-  <link rel="stylesheet" type="text/css" href="{{public_url}}maplibre-gl.css{{&key_query}}" />
-  <link rel="stylesheet" type="text/css" href="{{public_url}}maplibre-gl-inspect.css{{&key_query}}" />
-  <script>if (typeof Symbol !== 'undefined') { document.write('<script src="{{public_url}}maplibre-gl.js{{&key_query}}"><\/script>'); } else { document.write('<script src="{{public_url}}maplibre-gl-compat.js{{&key_query}}"><\/script>'); }</script>
-  <script>if (typeof Symbol !== 'undefined') { document.write('<script src="{{public_url}}maplibre-gl-inspect.min.js{{&key_query}}"><\/script>'); } else { document.write('<script src="{{public_url}}maplibre-gl-inspect-compat.min.js{{&key_query}}"><\/script>'); }</script>
+  <link rel="stylesheet" type="text/css" href="{{public_url}}maplibre-gl.css" />
+  <link rel="stylesheet" type="text/css" href="{{public_url}}maplibre-gl-inspect.css" />
+  <script>if (typeof Symbol !== 'undefined') { document.write('<script src="{{public_url}}maplibre-gl.js"><\/script>'); } else { document.write('<script src="{{public_url}}maplibre-gl-compat.js"><\/script>'); }</script>
+  <script>if (typeof Symbol !== 'undefined') { document.write('<script src="{{public_url}}maplibre-gl-inspect.min.js"><\/script>'); } else { document.write('<script src="{{public_url}}maplibre-gl-inspect-compat.min.js"><\/script>'); }</script>
   <style>
     body {background:#fff;color:#333;font-family:Arial, sans-serif;}
     #map {position:absolute;top:0;left:0;right:250px;bottom:0;}
@@ -18,10 +18,10 @@
   </style>
   {{/is_vector}}
   {{^is_vector}}
-  <link rel="stylesheet" type="text/css" href="{{public_url}}leaflet.css{{&key_query}}" />
-  <script src="{{public_url}}leaflet.js{{&key_query}}"></script>
-  <script src="{{public_url}}leaflet-hash.js{{&key_query}}"></script>
-  <script src="{{public_url}}L.TileLayer.NoGap.js{{&key_query}}"></script>
+  <link rel="stylesheet" type="text/css" href="{{public_url}}leaflet.css" />
+  <script src="{{public_url}}leaflet.js"></script>
+  <script src="{{public_url}}leaflet-hash.js"></script>
+  <script src="{{public_url}}L.TileLayer.NoGap.js"></script>
   <style>
     body { margin:0; padding:0; }
     #map { position:absolute; top:0; bottom:0; width:100%; }

--- a/public/templates/data.tmpl
+++ b/public/templates/data.tmpl
@@ -35,6 +35,9 @@
   <div id="layerList"></div>
   <pre id="propertyList"></pre>
   <script>
+  var keyMatch = location.search.match(/[\?\&]key=([^&]+)/i);
+  var keyParam = keyMatch ? '?key=' + keyMatch[1] : '';
+    
   var map = new maplibregl.Map({
     container: 'map',
     hash: true,
@@ -44,7 +47,7 @@
       sources: {
         'vector_layer_': {
           type: 'vector',
-          url: '{{public_url}}data/{{id}}.json{{&key_query}}'
+          url: '{{public_url}}data/{{id}}.json' + keyParam
         }
       },
       layers: []
@@ -76,11 +79,14 @@
   <h1 style="display:none;">{{name}}</h1>
   <div id='map'></div>
   <script>
+  var keyMatch = location.search.match(/[\?\&]key=([^&]+)/i);
+  var keyParam = keyMatch ? '?key=' + keyMatch[1] : '';    
+    
 	var map = L.map('map', { zoomControl: false });
 	new L.Control.Zoom({ position: 'topright' }).addTo(map);
 
 	var tile_urls = [], tile_attribution, tile_minzoom, tile_maxzoom;
-	var url = '{{public_url}}data/{{id}}.json{{&key_query}}';
+	var url = '{{public_url}}data/{{id}}.json' + keyParam;
 	var req = new XMLHttpRequest();
 	req.overrideMimeType("application/json");
 	req.open('GET', url, true);

--- a/public/templates/index.tmpl
+++ b/public/templates/index.tmpl
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>TileServer GL - Server for vector and raster maps with GL styles</title>
-  <link rel="stylesheet" type="text/css" href="{{public_url}}index.css{{&key_query}}" />
+  <link rel="stylesheet" type="text/css" href="{{public_url}}index.css" />
   <script>
     function toggle_xyz(id) {
       var el = document.getElementById(id);

--- a/public/templates/viewer.tmpl
+++ b/public/templates/viewer.tmpl
@@ -4,14 +4,14 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{{name}} - TileServer GL</title>
-  <link rel="stylesheet" type="text/css" href="{{public_url}}maplibre-gl.css{{&key_query}}" />
-  <link rel="stylesheet" type="text/css" href="{{public_url}}maplibre-gl-inspect.css{{&key_query}}" />
-  <link rel="stylesheet" type="text/css" href="{{public_url}}leaflet.css{{&key_query}}" />
-  <script>if (typeof Symbol !== 'undefined') { document.write('<script src="{{public_url}}maplibre-gl.js{{&key_query}}"><\/script>'); } else { document.write('<script src="{{public_url}}maplibre-gl-compat.js{{&key_query}}"><\/script>'); }</script>
-  <script>if (typeof Symbol !== 'undefined') { document.write('<script src="{{public_url}}maplibre-gl-inspect.min.js{{&key_query}}"><\/script>'); } else { document.write('<script src="{{public_url}}maplibre-gl-inspect-compat.min.js{{&key_query}}"><\/script>'); }</script>
-  <script src="{{public_url}}leaflet.js{{&key_query}}"></script>
-  <script src="{{public_url}}leaflet-hash.js{{&key_query}}"></script>
-  <script src="{{public_url}}L.TileLayer.NoGap.js{{&key_query}}"></script>
+  <link rel="stylesheet" type="text/css" href="{{public_url}}maplibre-gl.css" />
+  <link rel="stylesheet" type="text/css" href="{{public_url}}maplibre-gl-inspect.css" />
+  <link rel="stylesheet" type="text/css" href="{{public_url}}leaflet.css" />
+  <script>if (typeof Symbol !== 'undefined') { document.write('<script src="{{public_url}}maplibre-gl.js"><\/script>'); } else { document.write('<script src="{{public_url}}maplibre-gl-compat.js"><\/script>'); }</script>
+  <script>if (typeof Symbol !== 'undefined') { document.write('<script src="{{public_url}}maplibre-gl-inspect.min.js"><\/script>'); } else { document.write('<script src="{{public_url}}maplibre-gl-inspect-compat.min.js"><\/script>'); }</script>
+  <script src="{{public_url}}leaflet.js"></script>
+  <script src="{{public_url}}leaflet-hash.js"></script>
+  <script src="{{public_url}}L.TileLayer.NoGap.js"></script>
   <style>
     body { margin:0; padding:0; }
     #map { position:absolute; top:0; bottom:0; width:100%; }

--- a/public/templates/viewer.tmpl
+++ b/public/templates/viewer.tmpl
@@ -26,11 +26,14 @@
       q.indexOf('vector') >= 0 ? 'vector' :
         (q.indexOf('raster') >= 0 ? 'raster' :
           (maplibregl.supported() ? 'vector' : 'raster'));
+    var keyMatch = location.search.match(/[\?\&]key=([^&]+)/i);
+    var key = keyMatch ? '?key=' + keyMatch[1] : '';
+
     if (preference == 'vector') {
-      maplibregl.setRTLTextPlugin('{{public_url}}mapbox-gl-rtl-text.js{{&key_query}}');
+      maplibregl.setRTLTextPlugin('{{public_url}}mapbox-gl-rtl-text.js' + key);
       var map = new maplibregl.Map({
         container: 'map',
-        style: '{{public_url}}styles/{{id}}/style.json{{&key_query}}',
+        style: '{{public_url}}styles/{{id}}/style.json' + key,
         hash: true,
         maplibreLogo: true
       });
@@ -49,7 +52,7 @@
 		new L.Control.Zoom({ position: 'topright' }).addTo(map);
 		
 		var tile_urls = [], tile_attribution, tile_minzoom, tile_maxzoom;
-		var url = '{{public_url}}styles/{{id}}.json{{&key_query}}';
+		var url = '{{public_url}}styles/{{id}}.json' + key;
 		var req = new XMLHttpRequest();
 		req.overrideMimeType("application/json");
 		req.open('GET', url, true);

--- a/public/templates/viewer.tmpl
+++ b/public/templates/viewer.tmpl
@@ -26,14 +26,15 @@
       q.indexOf('vector') >= 0 ? 'vector' :
         (q.indexOf('raster') >= 0 ? 'raster' :
           (maplibregl.supported() ? 'vector' : 'raster'));
+
     var keyMatch = location.search.match(/[\?\&]key=([^&]+)/i);
-    var key = keyMatch ? '?key=' + keyMatch[1] : '';
+    var keyParam = keyMatch ? '?key=' + keyMatch[1] : '';    
 
     if (preference == 'vector') {
-      maplibregl.setRTLTextPlugin('{{public_url}}mapbox-gl-rtl-text.js' + key);
+      maplibregl.setRTLTextPlugin('{{public_url}}mapbox-gl-rtl-text.js' + keyParam);
       var map = new maplibregl.Map({
         container: 'map',
-        style: '{{public_url}}styles/{{id}}/style.json' + key,
+        style: '{{public_url}}styles/{{id}}/style.json' + keyParam,
         hash: true,
         maplibreLogo: true
       });
@@ -52,7 +53,7 @@
 		new L.Control.Zoom({ position: 'topright' }).addTo(map);
 		
 		var tile_urls = [], tile_attribution, tile_minzoom, tile_maxzoom;
-		var url = '{{public_url}}styles/{{id}}.json' + key;
+		var url = '{{public_url}}styles/{{id}}.json' + keyParam;
 		var req = new XMLHttpRequest();
 		req.overrideMimeType("application/json");
 		req.open('GET', url, true);


### PR DESCRIPTION
Fixes #532.

Using handlebars within javascript is pretty difficult to protect against, so this sidesteps it by using javascript to pull the query param off the page location and append to the RTL URL.

I used a regex because I thought perhaps this page was aiming for compatibility with very old browsers. If that's not the case, we could parse using `URLSearchParams` or something.