### PR TITLE
Make subsequent calls of `npm run docker` faster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-COPY . /usr/src/app
+COPY package.json /usr/src/app/package.json
 
 ENV NODE_ENV="production"
 
@@ -37,7 +37,9 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /usr/src/app /app
+RUN mkdir /app
+COPY --from=builder /usr/src/app/node_modules /app/node_modules
+COPY . /app
 
 ENV NODE_ENV="production"
 ENV CHOKIDAR_USEPOLLING=1


### PR DESCRIPTION
This makes subsequent calls of `npm run docker` a lot faster if source code was changed.

How it works:
- The build step only executes `npm install`. So it only needs the `package.json` file.
- By copying the whole project folder as late as possible, docker can use cached layers for all previous steps. This includes long-running steps like `apt-get` and `npm install`.