### PR TITLE
raster rendering: return HTTP error if Vector Tile cannot be fetched

### DIFF
--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -641,25 +641,30 @@ module.exports = {
                 const parts = url.parse(req.url);
                 const extension = path.extname(parts.pathname).toLowerCase();
                 const format = extensionToFormat[extension] || '';
-                if (err || res.statusCode < 200 || res.statusCode >= 300) {
+                // send empty response with status code 500 if vector tile server errors
+                if (res.statusCode >= 500) {
+                  console.log('HTTP error when fetching vector tile', err || res.statusCode);
+                  return false;
+                }
+                else if (err || res.statusCode < 200 || res.statusCode >= 300) {
                   // console.log('HTTP error', err || res.statusCode);
                   createEmptyResponse(format, '', callback);
                   return;
-                }
+                } else {
+                  const response = {};
+                  if (res.headers.modified) {
+                    response.modified = new Date(res.headers.modified);
+                  }
+                  if (res.headers.expires) {
+                    response.expires = new Date(res.headers.expires);
+                  }
+                  if (res.headers.etag) {
+                    response.etag = res.headers.etag;
+                  }
 
-                const response = {};
-                if (res.headers.modified) {
-                  response.modified = new Date(res.headers.modified);
+                  response.data = body;
+                  callback(null, response);
                 }
-                if (res.headers.expires) {
-                  response.expires = new Date(res.headers.expires);
-                }
-                if (res.headers.etag) {
-                  response.etag = res.headers.etag;
-                }
-
-                response.data = body;
-                callback(null, response);
               });
             }
           }


### PR DESCRIPTION
Currently tileserver returns an empty raster image if it fails loading one or more vector tiles.

This PR changes this behavior in cases where the vector tile server returns a status code 5xx.

In cases where vector tiles are generated dynamically by another service this is important in order to be able to retry failed tiles.