### PR TITLE
feat: allows resolving relative public urls into absolute urls

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -22,6 +22,12 @@ Getting started
     -s, --silent          Less verbose output
     -v, --version         Version info
 
+Resolve relative public url into an absolute url
+=====
+
+- Define environment variable TILESERVER_GL_RESOLVE_RELATIVE_PUBLIC_URL=true
+- Using this configuration will cause relative resource urls to be converted to absolute urls. This is needed for example to use tileserver-gl with mapbox-gl.
+- The absolute url will be resolved from the request protocol and host header and prepending them to the public_url option.
 
 Default preview style and configuration
 ======

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,7 +7,16 @@ const clone = require('clone');
 const glyphCompose = require('@mapbox/glyph-pbf-composite');
 
 
-module.exports.getPublicUrl = (publicUrl, req) => publicUrl || `${req.protocol}://${req.headers.host}/`;
+module.exports.getPublicUrl = (publicUrl, req) => {
+  if (publicUrl) {
+    const isRelative = !publicUrl.startsWith('http');
+    if (isRelative && process.env.TILESERVER_GL_RESOLVE_RELATIVE_PUBLIC_URL === 'true') {
+      return `${req.protocol}://${req.headers.host}${publicUrl}`;
+    }
+    return publicUrl;
+  }
+  return `${req.protocol}://${req.headers.host}/`;
+}
 
 module.exports.getTileUrls = (req, domains, path, format, publicUrl, aliases) => {
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,68 @@
+const { getPublicUrl } = require('../src/utils');
+const should = require('should');
+
+describe('Utils', () => {
+    describe('getPublicUrl', () => {
+        it('No public url provided returns request protocol and host', () => {
+            const req = {
+                protocol: 'http',
+                headers: {
+                    host: 'example.com'
+                }
+            };
+            const expected = 'http://example.com/';
+
+            const value = getPublicUrl(undefined, req);
+            should.equal(value, expected);
+        });
+        it('Absolute public url returns just the public url as it is', () => {
+            const req = {
+                protocol: 'http',
+                headers: {
+                    host: 'example.com'
+                }
+            };
+            const expected = 'http://as1.example.com/test/';
+            const publicUrl = 'http://as1.example.com/test/';
+
+            const value = getPublicUrl(publicUrl, req);
+
+            should.equal(value, expected);
+        });
+        it('Relative public url returns public url as an absolute url', () => {
+            try {
+                const req = {
+                    protocol: 'http',
+                    headers: {
+                        host: 'example.com'
+                    }
+                };
+                const expected = 'http://example.com/test/';
+    
+                const publicUrl = '/test/';
+                process.env.TILESERVER_GL_RESOLVE_RELATIVE_PUBLIC_URL = 'true';
+                
+                const value = getPublicUrl(publicUrl, req);
+    
+                should.equal(value, expected);
+            } finally {
+                process.env.TILESERVER_GL_RESOLVE_RELATIVE_PUBLIC_URL = undefined;
+            }
+        });
+        it('Relative public url returns public url as an relative url', () => {
+            const req = {
+                protocol: 'http',
+                headers: {
+                    host: 'example.com'
+                }
+            };
+            const expected = '/test/';
+
+            const publicUrl = '/test/';
+            
+            const value = getPublicUrl(publicUrl, req);
+
+            should.equal(value, expected);
+        });
+    });
+})


### PR DESCRIPTION
Hello,

I had an issue with using tileserver-gl running behind a proxy in a subdirectory. I also wanted to configure my web clients with relative urls so that map server url was /maps. Mapbox GL requires that urls that come from tileserver-gl are absolute URLs.

This feature enables the server to serve content from subdirectory so that all the relative urls are resolved into absolute urls.

This is an opt-in feature so it won't be enabled by default. You have to specify TILESERVER_GL_RESOLVE_RELATIVE_PUBLIC_URL=true env variable and public_url option for it to be enabled.