### PR TITLE
Simplify reloading the configuration with docker

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,6 +10,14 @@ handle() {
 
 trap handle INT TERM
 
+refresh() {
+	SIGNAL=$(( $? - 128 ))
+	echo "Caught signal ${SIGNAL}, refreshing"
+	kill -s ${SIGNAL} $(pidof node) 2>/dev/null
+}
+
+trap refresh HUP
+
 if ! which -- "${1}"; then
   # first arg is not an executable
   xvfb-run -a --server-args="-screen 0 1024x768x24" -- node /app/ "$@" &

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -29,12 +29,10 @@ Default preview style and configuration
 - If no configuration file is specified, a default preview style (compatible with openmaptiles) is used.
 - If no mbtiles file is specified (and is not found in the current working directory), a sample file is downloaded (showing the Zurich area)
 
-Reloading configuration
+Reloading the configuration
 ======
 
 It is possible to reload the configuration file without restarting the whole process by sending a SIGHUP signal to the node process.
 
-When running the tileserver-gl docker container, the signal must be sent from within the container:
-::
-
-  docker exec tileserver-gl bash -c 'kill -HUP $(ls -l /proc/*/exe | sed -n "/\/node$/s/.*proc\/\([0-9]\+\)\/exe .*/\1/p")'
+- The `docker kill -s HUP tileserver-gl` command can be used when running the tileserver-gl docker container.
+- The `docker-compose -s HUP tileserver-gl-service-name` can be used when tileserver-gl is run as a docker-compose service.


### PR DESCRIPTION
Allow `docker kill -s HUP` and `docker-compose kill -s HUP` to reach the node process.