### PR TITLE
Readme: Remove tileserver-gl-light docker

### DIFF
--- a/README_light.md
+++ b/README_light.md
@@ -27,9 +27,5 @@ docker build -t tileserver-gl-light .
 
 [Download from OpenMapTiles.com](https://openmaptiles.com/downloads/planet/) or [create](https://github.com/openmaptiles/openmaptiles) your vector tile, and run following in directory contains your *.mbtiles.
 
-```
-docker run --rm -it -v $(pwd):/data -p 8000:80 tileserver-gl-light
-```
-
 ## Documentation
 You can read full documentation of this project at https://tileserver.readthedocs.io/.


### PR DESCRIPTION
When following the readme `docker run --rm -it -v $(pwd):/data -p 8000:80 tileserver-gl-light` the error says:

```sh
% docker run --rm -it -v $(pwd):/data -p 8000:80 tileserver-gl-light
Unable to find image 'tileserver-gl-light:latest' locally
docker: Error response from daemon: pull access denied for tileserver-gl-light, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.
```

This removes the part of the documentation that is out of date.