### PR TITLE
CSS: Improve spacing for key-value-table

### DIFF
--- a/public/resources/mapbox-gl-inspect.css
+++ b/public/resources/mapbox-gl-inspect.css
@@ -18,9 +18,11 @@
 
 .mapbox-gl-inspect_property {
   display: table-row;
+  line-height: 120%;
 }
 
 .mapbox-gl-inspect_property-value {
+  padding-bottom: 6px;
   display: table-cell;
 
 }


### PR DESCRIPTION
After https://github.com/maptiler/tileserver-gl/pull/580, this change clarifies the table layout by keeping the strings with line break closer and giving some space to the next line.

![table-before](https://user-images.githubusercontent.com/111561/160415196-ebaeed40-8ea0-478a-9eec-d0f85908be6a.png)

![table-after](https://user-images.githubusercontent.com/111561/160415154-d8a09b91-bb9d-4686-acc1-0b92406f4e29.png)

