### PR TITLE
fix problems with some urls when use --public_url

### DIFF
--- a/public/resources/index.css
+++ b/public/resources/index.css
@@ -1,32 +1,3 @@
-@font-face {
-  font-family: 'OpenSans';
-  src: url('/fonts/OpenSans-Regular.ttf');
-  font-weight: normal;
-  font-style: normal;
-}
-@font-face {
-  font-family: 'OpenSans';
-  src: url('/fonts/OpenSans-Italic.ttf');
-  font-weight: normal;
-  font-style: italic;
-}
-@font-face {
-  font-family: 'OpenSans';
-  src: url('/fonts/OpenSans-Bold.ttf');
-  font-weight: bold;
-  font-style: normal;
-}
-
-body{
-  background-color: #fff;
-  color: #212121;
-  font-family:'OpenSans', sans-serif, Arial;
-  font-size: 14px;
-  margin:0;
-  background-repeat:no-repeat !important;
-  background-size: contain !important;
-  background-image: url(/images/header-map-1280px.png);
-}
 a{
   color: #499DCE;
   transition: color .2s;

--- a/public/templates/index.tmpl
+++ b/public/templates/index.tmpl
@@ -41,7 +41,7 @@
                 {{#if serving_data}}| {{/if}}<a href="{{public_url}}styles/{{@key}}.json{{&../key_query}}">TileJSON</a>
               {{/if}}
               {{#if serving_rendered}}
-                | <a href="/styles/{{@key}}/wmts.xml{{&../key_query}}">WMTS</a>
+                | <a href="{{public_url}}styles/{{@key}}/wmts.xml{{&../key_query}}">WMTS</a>
               {{/if}}
               {{#if xyz_link}}
                 | <a href="#" onclick="return toggle_xyz('xyz_style_{{@key}}');">XYZ</a>

--- a/public/templates/index.tmpl
+++ b/public/templates/index.tmpl
@@ -14,6 +14,37 @@
       return false;
     }
   </script>
+  <style>
+  @font-face {
+  font-family: "OpenSans";
+  src: url("{{public_url}}fonts/OpenSans-Regular.ttf");
+  font-weight: normal;
+  font-style: normal;
+}
+@font-face {
+  font-family: "OpenSans";
+  src: url("{{public_url}}fonts/OpenSans-Italic.ttf");
+  font-weight: normal;
+  font-style: italic;
+}
+@font-face {
+  font-family: "OpenSans";
+  src: url("{{public_url}}fonts/OpenSans-Bold.ttf");
+  font-weight: bold;
+  font-style: normal;
+}
+
+body{
+  background-color: #fff;
+  color: #212121;
+  font-family:"OpenSans", sans-serif, Arial;
+  font-size: 14px;
+  margin:0;
+  background-repeat:no-repeat !important;
+  background-size: contain !important;
+  background-image: url({{public_url}}/images/header-map-1280px.png);
+}
+  </style>
 </head>
 <body>
   <section>

--- a/public/templates/wmts.tmpl
+++ b/public/templates/wmts.tmpl
@@ -11,7 +11,7 @@
     <ows:Operation name="GetCapabilities">
       <ows:DCP>
         <ows:HTTP>
-          <ows:Get xlink:href="{{baseUrl}}/wmts/{{id}}/">
+          <ows:Get xlink:href="{{public_url}}wmts/{{id}}/">
             <ows:Constraint name="GetEncoding">
               <ows:AllowedValues>
                 <ows:Value>RESTful</ows:Value>
@@ -24,7 +24,7 @@
     <ows:Operation name="GetTile">
       <ows:DCP>
         <ows:HTTP>
-          <ows:Get xlink:href="{{baseUrl}}/styles/">
+          <ows:Get xlink:href="{{public_url}}styles/">
             <ows:Constraint name="GetEncoding">
               <ows:AllowedValues>
                 <ows:Value>RESTful</ows:Value>
@@ -50,7 +50,7 @@
       <TileMatrixSetLink>
         <TileMatrixSet>GoogleMapsCompatible</TileMatrixSet>
       </TileMatrixSetLink>
-      <ResourceURL format="image/png" resourceType="tile" template="{{baseUrl}}/styles/{{id}}/{TileMatrix}/{TileCol}/{TileRow}.png{{key_query}}"/>
+      <ResourceURL format="image/png" resourceType="tile" template="{{public_url}}styles/{{id}}/{TileMatrix}/{TileCol}/{TileRow}.png{{key_query}}"/>
     </Layer><TileMatrixSet>
       <ows:Title>GoogleMapsCompatible</ows:Title>
       <ows:Abstract>GoogleMapsCompatible EPSG:3857</ows:Abstract>
@@ -403,5 +403,5 @@
         <MatrixHeight>262144</MatrixHeight>
       </TileMatrix></TileMatrixSet>
   </Contents>
-  <ServiceMetadataURL xlink:href="{{baseUrl}}/wmts/{{id}}/"/>
+  <ServiceMetadataURL xlink:href="{{public_url}}wmts/{{id}}/"/>
 </Capabilities>


### PR DESCRIPTION
Hello

I've had some problems when trying to use tileserver-gl through a proxy.

These problems are related to the static files located in the path "/usr/src/app/public/"

The "wmts.tmpl" file does not contemplate the use of {{public_url}}, it always uses {{base_url}}

In the index.tmpl file in the wmts section, {{public_url}} is not considered in the link to the capabilities of the service.

In the index.css file all calls to styles that have url fail because they cannot be parameterized with {{public_url}}

If these styles are removed and included within index.tmpl in the header with <style> you can use {{public_url}}

These changes are minor and make it easier to use tileserver-gl through a proxy.

Thanks