### PR TITLE
591 - SQLite3 Vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@mapbox/glyph-pbf-composite": "0.0.3",
     "@mapbox/mapbox-gl-native": "5.0.2",
     "@mapbox/mapbox-gl-style-spec": "13.12.0",
-    "@mapbox/mbtiles": "0.11.0",
+    "@mapbox/mbtiles": "0.12.1",
     "@mapbox/sphericalmercator": "1.1.0",
     "@mapbox/vector-tile": "1.3.1",
     "advanced-pool": "0.3.3",


### PR DESCRIPTION
This updates the `@mapbox/mbtiles` version in package.json to utilize
`0.12.1` released about 2 years ago. This, in turn, utilizes `sqlite3`
version `5.x` which has patched vulnerabilities.

Closes #591