### PR TITLE
Add static renderer pool to fix static images

### DIFF
--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -229,9 +229,7 @@ module.exports = {
 
     const app = express().disable('x-powered-by');
 
-    const respondImage = (item, z, lon, lat, bearing, pitch,
-      width, height, scale, format, res, next,
-      opt_overlay) => {
+    const respondImage = (item, z, lon, lat, bearing, pitch, width, height, scale, format, res, next, opt_overlay, opt_mode="tile") => {
       if (Math.abs(lon) > 180 || Math.abs(lat) > 85.06 ||
         lon !== lon || lat !== lat) {
         return res.status(400).send('Invalid center');
@@ -248,7 +246,12 @@ module.exports = {
         return res.status(400).send('Invalid format');
       }
 
-      const pool = item.map.renderers[scale];
+      let pool;
+      if (opt_mode == 'tile') {
+        pool = item.map.renderers[scale];
+      } else {
+        pool = item.map.renderers_static[scale];
+      }
       pool.acquire((err, renderer) => {
         const mbglZ = Math.max(0, z - 1);
         const params = {
@@ -383,8 +386,7 @@ module.exports = {
         ((x + 0.5) / (1 << z)) * (256 << z),
         ((y + 0.5) / (1 << z)) * (256 << z)
       ], z);
-      return respondImage(item, z, tileCenter[0], tileCenter[1], 0, 0,
-        tileSize, tileSize, scale, format, res, next);
+      return respondImage(item, z, tileCenter[0], tileCenter[1], 0, 0, tileSize, tileSize, scale, format, res, next);
     });
 
     if (options.serveStaticMaps !== false) {
@@ -426,11 +428,9 @@ module.exports = {
         }
 
         const path = extractPathFromQuery(req.query, transformer);
-        const overlay = renderOverlay(z, x, y, bearing, pitch, w, h, scale,
-          path, req.query);
+        const overlay = renderOverlay(z, x, y, bearing, pitch, w, h, scale, path, req.query);
 
-        return respondImage(item, z, x, y, bearing, pitch, w, h, scale, format,
-          res, next, overlay);
+        return respondImage(item, z, x, y, bearing, pitch, w, h, scale, format, res, next, overlay, "static");
       });
 
       const serveBounds = (req, res, next) => {
@@ -468,10 +468,8 @@ module.exports = {
           pitch = 0;
 
         const path = extractPathFromQuery(req.query, transformer);
-        const overlay = renderOverlay(z, x, y, bearing, pitch, w, h, scale,
-          path, req.query);
-        return respondImage(item, z, x, y, bearing, pitch, w, h, scale, format,
-          res, next, overlay);
+        const overlay = renderOverlay(z, x, y, bearing, pitch, w, h, scale, path, req.query);
+        return respondImage(item, z, x, y, bearing, pitch, w, h, scale, format, res, next, overlay);
       };
 
       const boundsPattern =
@@ -542,11 +540,9 @@ module.exports = {
           x = center[0],
           y = center[1];
 
-        const overlay = renderOverlay(z, x, y, bearing, pitch, w, h, scale,
-          path, req.query);
+        const overlay = renderOverlay(z, x, y, bearing, pitch, w, h, scale, path, req.query);
 
-        return respondImage(item, z, x, y, bearing, pitch, w, h, scale, format,
-          res, next, overlay);
+        return respondImage(item, z, x, y, bearing, pitch, w, h, scale, format, res, next, overlay);
       });
     }
 
@@ -566,14 +562,15 @@ module.exports = {
   add: (options, repo, params, id, publicUrl, dataResolver) => {
     const map = {
       renderers: [],
+      renderers_static: [],
       sources: {}
     };
 
     let styleJSON;
-    const createPool = (ratio, min, max) => {
+    const createPool = (ratio, mode, min, max) => {
       const createRenderer = (ratio, createCallback) => {
         const renderer = new mbgl.Map({
-          mode: "tile",
+          mode: mode,
           ratio: ratio,
           request: (req, callback) => {
             const protocol = req.url.split(':')[0];
@@ -814,7 +811,8 @@ module.exports = {
         const j = Math.min(maxPoolSizes.length - 1, s - 1);
         const minPoolSize = minPoolSizes[i];
         const maxPoolSize = Math.max(minPoolSize, maxPoolSizes[j]);
-        map.renderers[s] = createPool(s, minPoolSize, maxPoolSize);
+        map.renderers[s] = createPool(s, "tile", minPoolSize, maxPoolSize);
+        map.renderers_static[s] = createPool(s, "static", minPoolSize, maxPoolSize);
       }
     });
 
@@ -824,6 +822,9 @@ module.exports = {
     let item = repo[id];
     if (item) {
       item.map.renderers.forEach(pool => {
+        pool.close();
+      });
+      item.map.renderers_static.forEach(pool => {
         pool.close();
       });
     }

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -247,7 +247,7 @@ module.exports = {
       }
 
       let pool;
-      if (opt_mode == 'tile') {
+      if (opt_mode === 'tile') {
         pool = item.map.renderers[scale];
       } else {
         pool = item.map.renderers_static[scale];
@@ -469,7 +469,7 @@ module.exports = {
 
         const path = extractPathFromQuery(req.query, transformer);
         const overlay = renderOverlay(z, x, y, bearing, pitch, w, h, scale, path, req.query);
-        return respondImage(item, z, x, y, bearing, pitch, w, h, scale, format, res, next, overlay);
+        return respondImage(item, z, x, y, bearing, pitch, w, h, scale, format, res, next, overlay, "static");
       };
 
       const boundsPattern =
@@ -542,7 +542,7 @@ module.exports = {
 
         const overlay = renderOverlay(z, x, y, bearing, pitch, w, h, scale, path, req.query);
 
-        return respondImage(item, z, x, y, bearing, pitch, w, h, scale, format, res, next, overlay);
+        return respondImage(item, z, x, y, bearing, pitch, w, h, scale, format, res, next, overlay, "static");
       });
     }
 


### PR DESCRIPTION
This adds a second pool of renderers that are in static mode instead tile mode. This works around a change in maplibre-native that only returns one tile when in tile mode, which causes static images with multiple tiles to fail to load completely.

Without this change, tileserver reports the following warning
```
mbgl: {
  class: 'General',
  severity: 'WARNING',
  text: 'Provided camera options returned 4 tiles, only 11/1100/671=>11 is taken in Tile mode.'
}
```
and the image looks like this
![500x500_old](https://user-images.githubusercontent.com/3792408/191411639-84b87ea9-6a77-4ed4-ba62-e77f529e38ae.png)

After this change, the warning does not show and the static image looks like this
![500x500_new](https://user-images.githubusercontent.com/3792408/191411854-19a1a30a-0917-46e1-98e0-28f8b92ccf14.png)

