### PR TITLE
Update all packages to their latest release

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,26 +24,26 @@
     "@mapbox/sphericalmercator": "1.2.0",
     "@mapbox/vector-tile": "1.3.1",
     "advanced-pool": "0.3.3",
-    "canvas": "2.9.3",
-    "chokidar": "3.3.1",
+    "canvas": "2.10.1",
+    "chokidar": "3.5.3",
     "clone": "2.1.2",
-    "color": "3.1.2",
+    "color": "4.2.3",
     "commander": "9.4.0",
     "cors": "2.8.5",
     "esm": "3.2.25",
-    "express": "4.17.1",
-    "handlebars": "4.7.3",
+    "express": "4.18.1",
+    "handlebars": "4.7.7",
     "http-shutdown": "1.2.2",
-    "morgan": "1.9.1",
+    "morgan": "1.10.0",
     "pbf": "3.2.1",
-    "proj4": "2.6.0",
+    "proj4": "2.8.0",
     "request": "2.88.2",
-    "sharp": "0.26.2",
+    "sharp": "0.31.0",
     "tileserver-gl-styles": "2.0.0"
   },
   "devDependencies": {
-    "mocha": "^7.1.0",
+    "mocha": "^10.0.0",
     "should": "^13.2.3",
-    "supertest": "^4.0.2"
+    "supertest": "^6.2.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "license": "BSD-2-Clause",
   "engines": {
-    "node": ">=10 <17"
+    "node": ">=14.15.0 <17"
   },
   "scripts": {
     "test": "mocha test/**.js --timeout 10000",


### PR DESCRIPTION
This updates all the packages to their latest release. I think it is important to update these packages and fix our vulnerabilities before out 4.0.0 docker release. Due to the sharp update, the minimum node is 14.15.0 after the updates. 

```
root@mapgen2:/opt/test7/tileserver-gl# npm i
up to date, audited 497 packages in 1s

72 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```

```
root@mapgen2:/opt/test7/tileserver-gl# xvfb-run --server-args="-screen 0 1024x768x24" npm test

> tileserver-gl@3.1.1 test
> mocha test/**.js --timeout 10000



global setup
Starting server
Listening at http://[::]:8888/
Startup complete
  Metadata
    /health
      ✔ returns 200
    /index.json is array of TileJSONs
      ✔ is json
      ✔ is non-empty array
    /rendered.json is array of TileJSONs
      ✔ is json
      ✔ is non-empty array
    /data.json is array of TileJSONs
      ✔ is json
      ✔ is non-empty array
    /styles.json is valid array
      ✔ is json
      ✔ contains valid item
    /styles/test-style.json is TileJSON
      ✔ is json
      ✔ has valid tiles
    /data/openmaptiles.json is TileJSON
      ✔ is json
      ✔ has valid tiles

  Static endpoints
    center-based
      valid requests
        various formats
          ✔ /styles/test-style/static/0,0,0/256x256.png returns 200 (148ms)
          ✔ /styles/test-style/static/0,0,0/256x256.jpg returns 200 (92ms)
          ✔ /styles/test-style/static/0,0,0/256x256.jpeg returns 200 (85ms)
          ✔ /styles/test-style/static/0,0,0/256x256.webp returns 200 (89ms)
        different parameters
          ✔ /styles/test-style/static/0,0,0/300x300@2x.png returns 200 (190ms)
          ✔ /styles/test-style/static/0,0,0/300x300@3x.png returns 200 (334ms)
          ✔ /styles/test-style/static/0,0,1.5/256x256.png returns 200 (51ms)
          ✔ /styles/test-style/static/80,40,20/600x300@3x.png returns 200 (47ms)
          ✔ /styles/test-style/static/8.5,40.5,20/300x150@3x.png returns 200
          ✔ /styles/test-style/static/-8.5,-40.5,20/300x150@3x.png returns 200
          ✔ /styles/test-style/static/8,40,2@0,0/300x150.png returns 200 (46ms)
          ✔ /styles/test-style/static/8,40,2@180,45/300x150@2x.png returns 200 (47ms)
          ✔ /styles/test-style/static/8,40,2@10/300x150@3x.png returns 200
          ✔ /styles/test-style/static/8,40,2@10.3,20.4/300x300.png returns 200 (46ms)
          ✔ /styles/test-style/static/0,0,2@390,120/300x300.png returns 200 (45ms)
      invalid requests return 4xx
        ✔ /styles/test-style/static/190,0,0/256x256.png returns 400
        ✔ /styles/test-style/static/0,86,0/256x256.png returns 400
        ✔ /styles/test-style/static/80,40,20/0x0.png returns 400
        ✔ /styles/test-style/static/0,0,0/256x256.gif returns 400
        ✔ /styles/test-style/static/0,0,0/256x256@1x.png returns 404
        ✔ /styles/test-style/static/0,0,-1/256x256.png returns 404
        ✔ /styles/test-style/static/0,0,0/256.5x256.5.png returns 404
        ✔ /styles/test-style/static/0,0,0,/256x256.png returns 404
        ✔ /styles/test-style/static/0,0,0,0,/256x256.png returns 404
    area-based
      valid requests
        various formats
          ✔ /styles/test-style/static/-180,-80,180,80/10x10.png returns 200
          ✔ /styles/test-style/static/-180,-80,180,80/10x10.jpg returns 200
          ✔ /styles/test-style/static/-180,-80,180,80/10x10.jpeg returns 200
          ✔ /styles/test-style/static/-180,-80,180,80/10x10.webp returns 200
        different parameters
          ✔ /styles/test-style/static/-180,-90,180,90/20x20@2x.png returns 200 (38ms)
          ✔ /styles/test-style/static/0,0,1,1/200x200@3x.png returns 200
          ✔ /styles/test-style/static/-280,-80,0,80/280x160.png returns 200
      invalid requests return 4xx
        ✔ /styles/test-style/static/0,87,1,88/5x2.png returns 400
        ✔ /styles/test-style/static/0,0,1,1/1x1.gif returns 400
        ✔ /styles/test-style/static/-180,-80,180,80/0.5x2.6.png returns 404
    autofit path
      valid requests
        ✔ /styles/test-style/static/auto/256x256.png?path=10,10|20,20 returns 200
        different parameters
          ✔ /styles/test-style/static/auto/20x20@2x.png?path=10,10|20,20 returns 200 (46ms)
          ✔ /styles/test-style/static/auto/200x200@3x.png?path=-10,-10|-20,-20 returns 200 (51ms)
      invalid requests return 4xx
        ✔ /styles/test-style/static/auto/256x256.png returns 400
        ✔ /styles/test-style/static/auto/256x256.png?path=10,10 returns 400
        ✔ /styles/test-style/static/auto/2560x2560.png?path=10,10|20,20 returns 400 (218ms)

  Styles
    /styles/test-style/style.json is valid style
      ✔ /styles/test-style/style.json return 200 and is /application\/json/
      ✔ contains expected properties
    /styles/streets/style.json is not served
      ✔ /styles/streets/style.json return 404 and is /./
    /styles/test-style/sprite[@2x].{format}
      ✔ /styles/test-style/sprite.json return 200 and is /application\/json/
      ✔ /styles/test-style/sprite@2x.json return 200 and is /application\/json/
      ✔ /styles/test-style/sprite.png return 200 and is /image\/png/
      ✔ /styles/test-style/sprite@2x.png return 200 and is /image\/png/

  Fonts
    ✔ /fonts/Open Sans Bold/0-255.pbf return 200 and is /application\/x-protobuf/
    ✔ /fonts/Open Sans Regular/65280-65535.pbf return 200 and is /application\/x-protobuf/
    ✔ /fonts/Open Sans Bold,Open Sans Regular/0-255.pbf return 200 and is /application\/x-protobuf/
    ✔ /fonts/Nonsense,Open Sans Bold/0-255.pbf return 400 and is /./
    ✔ /fonts/Nonsense/0-255.pbf return 400 and is /./
    ✔ /fonts/Nonsense1,Nonsense2/0-255.pbf return 400 and is /./

  Vector tiles
    existing tiles
      ✔ /data/openmaptiles/0/0/0.pbf returns 200
      ✔ /data/openmaptiles/14/8581/5738.pbf returns 200
    non-existent requests return 4xx
      ✔ /data/non_existent/0/0/0.pbf returns 404
      ✔ /data/openmaptiles/-1/0/0.pbf returns 404
      ✔ /data/openmaptiles/20/0/0.pbf returns 404
      ✔ /data/openmaptiles/0/1/0.pbf returns 404
      ✔ /data/openmaptiles/0/0/1.pbf returns 404
      ✔ /data/openmaptiles/14/0/0.pbf returns 204

  Raster tiles
    valid requests
      various formats
        ✔ /styles/test-style/0/0/0.png returns 200 (84ms)
        ✔ /styles/test-style/0/0/0.jpg returns 200 (70ms)
        ✔ /styles/test-style/0/0/0.jpeg returns 200 (85ms)
        ✔ /styles/test-style/0/0/0.webp returns 200 (84ms)
      different coordinates and scales
        ✔ /styles/test-style/1/1/1.png returns 200 (49ms)
        ✔ /styles/test-style/0/0/0@2x.png returns 200 (133ms)
        ✔ /styles/test-style/0/0/0@3x.png returns 200 (243ms)
        ✔ /styles/test-style/2/1/1@3x.png returns 200
    invalid requests return 4xx
      ✔ /styles/non_existent/0/0/0.png returns 404
      ✔ /styles/test-style/-1/0/0.png returns 404
      ✔ /styles/test-style/25/0/0.png returns 404
      ✔ /styles/test-style/0/1/0.png returns 404
      ✔ /styles/test-style/0/0/1.png returns 404
      ✔ /styles/test-style/0/0/0.gif returns 400
      ✔ /styles/test-style/0/0/0.pbf returns 400
      ✔ /styles/test-style/0/0/0@1x.png returns 404
      ✔ /styles/test-style/0/0/0@5x.png returns 404

global teardown

  91 passing (4s)

Done
```
