### PR TITLE
Don't include duplicate attributions

### DIFF
--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -792,10 +792,12 @@ module.exports = {
 
               if (!attributionOverride &&
                 source.attribution && source.attribution.length > 0) {
-                if (tileJSON.attribution.length > 0) {
-                  tileJSON.attribution += '; ';
+                if (!tileJSON.attribution.includes(source.attribution)) {
+                  if (tileJSON.attribution.length > 0) {
+                    tileJSON.attribution += ' | ';
+                  }
+                  tileJSON.attribution += source.attribution;
                 }
-                tileJSON.attribution += source.attribution;
               }
               resolve();
             });


### PR DESCRIPTION
Check to see if tileJSON already has a particular attribution before appending it again.

Longer term I'd probably keep `attributions` in an array and `join(' | ')` at the end, but we'd probably need some more cleanup before that is viable.