### PR TITLE
Extended Static-Images Endpoint

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -32,6 +32,7 @@ Example:
       "serveAllFonts": false,
       "serveAllStyles": false,
       "serveStaticMaps": true,
+      "allowRemoteMarkerIcons": true,
       "tileMargin": 0
     },
     "styles": {
@@ -141,6 +142,13 @@ It is recommended to also use the ``serveAllFonts`` option when using this optio
 Optional string to be rendered into the raster tiles (and static maps) as watermark (bottom-left corner).
 Can be used for hard-coding attributions etc. (can also be specified per-style).
 Not used by default.
+
+``allowRemoteMarkerIcons``
+--------------
+
+Allows the rendering of marker icons fetched via http(s) hyperlinks.
+For security reasons only allow this if you can control the origins from where the markers are fetched!
+Default is to disallow fetching of icons from remote sources.
 
 ``styles``
 ==========

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -14,6 +14,7 @@ Example:
         "root": "",
         "fonts": "fonts",
         "sprites": "sprites",
+        "icons": "icons",
         "styles": "styles",
         "mbtiles": ""
       },

--- a/docs/endpoints.rst
+++ b/docs/endpoints.rst
@@ -38,6 +38,7 @@ Static images
   * ``path`` - comma-separated ``lng,lat``, pipe-separated pairs
 
     * e.g. ``5.9,45.8|5.9,47.8|10.5,47.8|10.5,45.8|5.9,45.8``
+    * can be provided multiple times
 
   * ``latlng`` - indicates coordinates are in ``lat,lng`` order rather than the usual ``lng,lat``
   * ``fill`` - color to use as the fill (e.g. ``red``, ``rgba(255,255,255,0.5)``, ``#0000ff``)
@@ -63,8 +64,8 @@ Static images
         * scales with ``scale`` parameter since image placement is relative to it's size
         * e.g. ``2,-4`` - Image will be moved 2 pixel to the right and 4 pixel in the upwards direction from the provided location
 
-    * can be provided multiple times
     * e.g. ``5.9,45.8|marker-start.svg|scale:0.5|offset:2,-4``
+    * can be provided multiple times
 
   * ``padding`` - "percentage" padding for fitted endpoints (area-based and path autofit)
 

--- a/docs/endpoints.rst
+++ b/docs/endpoints.rst
@@ -39,13 +39,37 @@ Static images
 
     * e.g. ``5.9,45.8|5.9,47.8|10.5,47.8|10.5,45.8|5.9,45.8``
 
-  * ``latlng`` - indicates the ``path`` coordinates are in ``lat,lng`` order rather than the usual ``lng,lat``
+  * ``latlng`` - indicates coordinates are in ``lat,lng`` order rather than the usual ``lng,lat``
   * ``fill`` - color to use as the fill (e.g. ``red``, ``rgba(255,255,255,0.5)``, ``#0000ff``)
   * ``stroke`` - color of the path stroke
   * ``width`` - width of the stroke
+  * ``linecap`` - line cap of the path stroke
+  * ``border`` - color of the optional border path stroke
+  * ``borderwidth`` - width of the border stroke (default 10% of width)
+  * ``marker`` - Marker in format ``lng,lat|iconPath|option|option|...``
+
+    * Will be rendered with the bottom center at the provided location
+    * ``lng,lat`` and ``iconPath`` are mandatory and icons won't be rendered without them
+    * ``iconPath`` is either a link to an image served via http(s) or a path to a file relative to the configured icon path
+    * ``option`` must adhere to the format ``optionName:optionValue`` and supports the following names
+
+      * ``scale`` - Factor to scale image by
+
+        * e.g. ``0.5`` - Scales the image to half it's original size
+
+      * ``offset`` - Image offset as positive or negative pixel value in format ``[offsetX],[offsetY]``
+
+        * scales with ``scale`` parameter since image placement is relative to it's size
+        * e.g. ``2,-4`` - Image will be moved 2 pixel to the right and 4 pixel in the upwards direction from the provided location
+
+    * can be provided multiple times
+    * e.g. ``5.9,45.8|marker-start.svg|scale:0.5|offset:2,-4``
+
   * ``padding`` - "percentage" padding for fitted endpoints (area-based and path autofit)
 
     * value of ``0.1`` means "add 10% size to each side to make sure the area of interest is nicely visible"
+
+  * ``maxzoom`` - Maximum zoom level (only for auto endpoint where zoom level is calculated and not provided)
 
 * You can also use (experimental) ``/styles/{id}/static/raw/...`` endpoints with raw spherical mercator coordinates (EPSG:3857) instead of WGS84.
 

--- a/docs/endpoints.rst
+++ b/docs/endpoints.rst
@@ -43,7 +43,8 @@ Static images
   * ``fill`` - color to use as the fill (e.g. ``red``, ``rgba(255,255,255,0.5)``, ``#0000ff``)
   * ``stroke`` - color of the path stroke
   * ``width`` - width of the stroke
-  * ``linecap`` - line cap of the path stroke
+  * ``linecap`` - rendering style for the start and end points of the path
+  * ``linejoin`` - rendering style for overlapping segments of the path with differing directions
   * ``border`` - color of the optional border path stroke
   * ``borderwidth`` - width of the border stroke (default 10% of width)
   * ``marker`` - Marker in format ``lng,lat|iconPath|option|option|...``

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "proj4": "2.8.0",
     "request": "2.88.2",
     "sharp": "0.31.0",
-    "tileserver-gl-styles": "2.0.0"
+    "tileserver-gl-styles": "2.0.0",
+    "sanitize-filename": "1.6.3"
   },
   "devDependencies": {
     "chai": "4.3.6",

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -410,8 +410,13 @@ const drawPath = async (ctx, path, query, z) => {
     const borderWidth = query.borderwidth !== undefined ?
       parseFloat(query.borderwidth) : lineWidth * 0.1;
 
-    // Set line start/endpoint style
+    // Set rendering style for the start and end points of the path
+    // https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineCap
     ctx.lineCap = query.linecap || 'butt';
+
+    // Set rendering style for overlapping segments of the path with differing directions
+    // https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineJoin
+    ctx.lineJoin = query.linejoin || 'miter';
 
     // In order to simulate a border we draw the path two times with the first
     // beeing the wider border part.

--- a/src/server.js
+++ b/src/server.js
@@ -95,6 +95,35 @@ export function server(opts) {
   checkPath('mbtiles');
   checkPath('icons');
 
+  /**
+ * Recursively get all files within a directory.
+ * Inspired by https://stackoverflow.com/a/45130990/10133863
+ * @param {String} directory Absolute path to a directory to get files from.
+ */
+  const getFiles = async (directory) => {
+    // Fetch all entries of the directory and attach type information
+    const dirEntries = await fs.promises.readdir(directory, { withFileTypes: true });
+
+    // Iterate through entries and return the relative file-path to the icon directory if it is not a directory
+    // otherwise initiate a recursive call
+    const files = await Promise.all(dirEntries.map((dirEntry) => {
+      const entryPath = path.resolve(directory, dirEntry.name);
+      return dirEntry.isDirectory() ?
+        getFiles(entryPath) : entryPath.replace(paths.icons + path.sep, "");
+    }));
+
+    // Flatten the list of files to a single array
+    return files.flat();
+  }
+
+  // Load all available icons into a settings object
+  startupPromises.push(new Promise(resolve => {
+    getFiles(paths.icons).then((files) => {
+      paths.availableIcons = files;
+      resolve();
+    });
+  }));
+
   if (options.dataDecorator) {
     try {
       options.dataDecoratorFunc = require(path.resolve(paths.root, options.dataDecorator));

--- a/src/server.js
+++ b/src/server.js
@@ -79,6 +79,7 @@ export function server(opts) {
   paths.fonts = path.resolve(paths.root, paths.fonts || '');
   paths.sprites = path.resolve(paths.root, paths.sprites || '');
   paths.mbtiles = path.resolve(paths.root, paths.mbtiles || '');
+  paths.icons = path.resolve(paths.root, paths.icons || '');
 
   const startupPromises = [];
 
@@ -92,6 +93,7 @@ export function server(opts) {
   checkPath('fonts');
   checkPath('sprites');
   checkPath('mbtiles');
+  checkPath('icons');
 
   if (options.dataDecorator) {
     try {

--- a/test/static.js
+++ b/test/static.js
@@ -95,7 +95,7 @@ describe('Static endpoints', function() {
 
     describe('invalid requests return 4xx', function() {
       testStatic(prefix, 'auto/256x256', 'png', 400);
-      testStatic(prefix, 'auto/256x256', 'png', 400, undefined, undefined, '?path=10,10');
+      testStatic(prefix, 'auto/256x256', 'png', 400, undefined, undefined, '?path=invalid');
       testStatic(prefix, 'auto/2560x2560', 'png', 400, undefined, undefined, '?path=10,10|20,20');
     });
   });


### PR DESCRIPTION
I have Extended the Static-Images Endpoint with the following capabilities:

- Optional border with configurable color and width for paths via the `border` and `borderwidth` parameters
- Optional markers with the following configurable options:
  - Icon provided locally via the icons path or as a hyperlink (enabled via `allowRemoteMarkerIcons` setting)
  - Scale of the image relative to its original size
  - Offset in pixels
- Linecap of the path https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineCap
- Linejoin of the path https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/lineJoin
- Capability to provide multiple paths
- Maximum zoom level if autofit is selected when providing a path

Additional Changes:

- In order to keep performance drawing of elements has been refactored to be asynchronous
- Refactored a lot of helpers in serve_rendered.js to be more modular and reusable


Please let me know if this would be interesting to you.

Cheers :)
