### PR TITLE
Move docker images to ubuntu

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 *
 !src
 !public
+!test
 !package.json
 !package-lock.json
 !docker-entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,18 +4,35 @@ ENV NODE_ENV="production"
 
 RUN set -ex; \
     export DEBIAN_FRONTEND=noninteractive; \
+    groupadd -r node; \
+    useradd -r -g node node; \
     apt-get -qq update; \
     apt-get -y --no-install-recommends install \
+      build-essential \
       ca-certificates \
-      wget; \
+      wget \
+      pkg-config \
+      xvfb \
+      libglfw3-dev \
+      libuv1-dev \
+      libjpeg-turbo8 \
+      libicu66 \
+      libcairo2-dev \
+      libpango1.0-dev \
+      libjpeg-dev \
+      libgif-dev \
+      librsvg2-dev \
+      libcurl4-openssl-dev \
+      libpixman-1-dev; \
     wget -qO- https://deb.nodesource.com/setup_16.x | bash; \
     apt-get install -y nodejs; \
     apt-get -y remove wget; \
     apt-get -y --purge autoremove; \
     apt-get clean; \
     rm -rf /var/lib/apt/lists/*;
-  
-COPY . /usr/src/app
+
+RUN mkdir -p /usr/src/app
+COPY package.json package-lock.json /usr/src/app
 
 RUN cd /usr/src/app && npm install --production
 
@@ -34,13 +51,18 @@ RUN set -ex; \
     apt-get -y --no-install-recommends install \
       ca-certificates \
       wget \
-      pkg-config \
       xvfb \
-      libglfw3-dev \
-      libuv1-dev \
+      libglfw3 \
+      libuv1 \
       libjpeg-turbo8 \
       libicu66 \
-      libcurl4-openssl-dev; \
+      libcairo2 \
+      libgif7 \
+      libopengl0 \
+      libpixman-1-0 \
+      libcurl4 \
+      librsvg2-2 \
+      libpango1.0; \
     wget -qO- https://deb.nodesource.com/setup_16.x | bash; \
     apt-get install -y nodejs; \
     apt-get -y remove wget; \
@@ -48,7 +70,9 @@ RUN set -ex; \
     apt-get clean; \
     rm -rf /var/lib/apt/lists/*;
 
-COPY --from=builder /usr/src/app /app
+COPY --from=builder /usr/src/app /usr/src/app
+
+COPY . /usr/src/app
 
 VOLUME /data
 WORKDIR /data
@@ -57,4 +81,4 @@ EXPOSE 80
 
 USER node:node
 
-ENTRYPOINT ["/app/docker-entrypoint.sh"]
+ENTRYPOINT ["/usr/src/app/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN set -ex; \
     rm -rf /var/lib/apt/lists/*;
 
 RUN mkdir -p /usr/src/app
-COPY package.json package-lock.json /usr/src/app
+COPY package.json /usr/src/app
 
 RUN cd /usr/src/app && npm install --production
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,38 @@
 FROM ubuntu:focal AS builder
 
-RUN export DEBIAN_FRONTEND=noninteractive \
-  && apt-get -qq update \
-  && apt-get -y --no-install-recommends install \
+ENV \
+    NODE_ENV="production" \
+    DEBIAN_FRONTEND=noninteractive
+
+RUN set -ex; \
+    apt-get -qq update; \
+    apt-get -y --no-install-recommends install \
       ca-certificates \
-      wget \
-  && apt-get -y --purge autoremove \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
+      wget; \
+    wget -qO- https://deb.nodesource.com/setup_16.x | bash; \
+    apt-get install -y nodejs; \
+    apt-get -y remove wget; \
+    apt-get -y --purge autoremove; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*;
   
-RUN wget -qO- https://deb.nodesource.com/setup_16.x | bash
-RUN apt-get install -y nodejs
-
 COPY . /usr/src/app
-
-ENV NODE_ENV="production"
 
 RUN cd /usr/src/app && npm install --production
 
-
 FROM ubuntu:focal AS final
 
-RUN groupadd -r node && useradd -r -g node node
+ENV \
+    NODE_ENV="production" \
+    CHOKIDAR_USEPOLLING=1 \
+    CHOKIDAR_INTERVAL=500 \
+    DEBIAN_FRONTEND=noninteractive
 
-RUN export DEBIAN_FRONTEND=noninteractive \
-  && apt-get -qq update \
-  && apt-get -y --no-install-recommends install \
+RUN set -ex; \
+    groupadd -r node; \
+    useradd -r -g node node; \
+    apt-get -qq update; \
+    apt-get -y --no-install-recommends install \
       ca-certificates \
       wget \
       pkg-config \
@@ -34,20 +41,15 @@ RUN export DEBIAN_FRONTEND=noninteractive \
       libuv1-dev \
       libjpeg-turbo8 \
       libicu66 \
-      unzip \
-      libcurl4-openssl-dev \
-  && apt-get -y --purge autoremove \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
-
-RUN wget -qO- https://deb.nodesource.com/setup_16.x | bash
-RUN apt-get install -y nodejs
+      libcurl4-openssl-dev; \
+    wget -qO- https://deb.nodesource.com/setup_16.x | bash; \
+    apt-get install -y nodejs; \
+    apt-get -y remove wget; \
+    apt-get -y --purge autoremove; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*;
 
 COPY --from=builder /usr/src/app /app
-
-ENV NODE_ENV="production"
-ENV CHOKIDAR_USEPOLLING=1
-ENV CHOKIDAR_INTERVAL=500
 
 VOLUME /data
 WORKDIR /data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,16 @@
-FROM node:16-bullseye AS builder
+FROM ubuntu:focal AS builder
 
 RUN export DEBIAN_FRONTEND=noninteractive \
   && apt-get -qq update \
   && apt-get -y --no-install-recommends install \
-      apt-transport-https \
-      curl \
-      unzip \
-      build-essential \
-      python \
-      libcairo2-dev \
-      libgles2-mesa-dev \
-      libgbm-dev \
-      libprotobuf-dev \
+      ca-certificates \
+      wget \
   && apt-get -y --purge autoremove \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
+  
+RUN wget -qO- https://deb.nodesource.com/setup_16.x | bash
+RUN apt-get install -y nodejs
 
 COPY . /usr/src/app
 
@@ -23,29 +19,29 @@ ENV NODE_ENV="production"
 RUN cd /usr/src/app && npm install --production
 
 
-FROM node:16-bullseye-slim AS final
+FROM ubuntu:focal AS final
+
+RUN groupadd -r node && useradd -r -g node node
 
 RUN export DEBIAN_FRONTEND=noninteractive \
   && apt-get -qq update \
   && apt-get -y --no-install-recommends install \
-      libgles2-mesa \
-      libegl1 \
+      ca-certificates \
+      wget \
+      pkg-config \
       xvfb \
-      xauth \
-      libopengl0 \
-      libcurl4 \
-      curl \
+      libglfw3-dev \
       libuv1-dev \
-      libc6-dev \
-      libcap2-bin \
+      libjpeg-turbo8 \
+      libicu66 \
+      unzip \
+      libcurl4-openssl-dev \
   && apt-get -y --purge autoremove \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
-  
-RUN curl http://archive.ubuntu.com/ubuntu/pool/main/libj/libjpeg-turbo/libjpeg-turbo8_2.0.3-0ubuntu1_amd64.deb --output libjpeg-turbo8_2.0.3-0ubuntu1_amd64.deb
-RUN apt install ./libjpeg-turbo8_2.0.3-0ubuntu1_amd64.deb
-RUN curl http://archive.ubuntu.com/ubuntu/pool/main/i/icu/libicu66_66.1-2ubuntu2_amd64.deb --output libicu66_66.1-2ubuntu2_amd64.deb
-RUN apt install ./libicu66_66.1-2ubuntu2_amd64.deb
+
+RUN wget -qO- https://deb.nodesource.com/setup_16.x | bash
+RUN apt-get install -y nodejs
 
 COPY --from=builder /usr/src/app /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,6 @@ ENV NODE_ENV="production"
 
 RUN set -ex; \
     export DEBIAN_FRONTEND=noninteractive; \
-    groupadd -r node; \
-    useradd -r -g node node; \
     apt-get -qq update; \
     apt-get -y --no-install-recommends install \
       build-essential \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
 FROM ubuntu:focal AS builder
 
-ENV \
-    NODE_ENV="production" \
-    DEBIAN_FRONTEND=noninteractive
+ENV NODE_ENV="production"
 
 RUN set -ex; \
+    export DEBIAN_FRONTEND=noninteractive; \
     apt-get -qq update; \
     apt-get -y --no-install-recommends install \
       ca-certificates \
@@ -25,10 +24,10 @@ FROM ubuntu:focal AS final
 ENV \
     NODE_ENV="production" \
     CHOKIDAR_USEPOLLING=1 \
-    CHOKIDAR_INTERVAL=500 \
-    DEBIAN_FRONTEND=noninteractive
+    CHOKIDAR_INTERVAL=500
 
 RUN set -ex; \
+    export DEBIAN_FRONTEND=noninteractive; \
     groupadd -r node; \
     useradd -r -g node node; \
     apt-get -qq update; \

--- a/Dockerfile_light
+++ b/Dockerfile_light
@@ -1,21 +1,25 @@
 FROM ubuntu:focal
 
-RUN export DEBIAN_FRONTEND=noninteractive \
-  && apt-get -qq update \
-  && apt-get -y --no-install-recommends install \
-      ca-certificates \
-      wget \
-  && apt-get -y --purge autoremove \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
-  
-RUN wget -qO- https://deb.nodesource.com/setup_16.x | bash
-RUN apt-get install -y nodejs
-RUN groupadd -r node && useradd -r -g node node
+ENV \
+    NODE_ENV="production" \
+    CHOKIDAR_USEPOLLING=1 \
+    CHOKIDAR_INTERVAL=500 \
+    DEBIAN_FRONTEND=noninteractive
 
-ENV NODE_ENV="production"
-ENV CHOKIDAR_USEPOLLING=1
-ENV CHOKIDAR_INTERVAL=500
+RUN set -ex; \
+    groupadd -r node; \
+    useradd -r -g node node; \
+    apt-get -qq update; \
+    apt-get -y --no-install-recommends install \
+      ca-certificates \
+      wget; \
+    wget -qO- https://deb.nodesource.com/setup_16.x | bash; \
+    apt-get install -y nodejs; \
+    apt-get -y remove wget; \
+    apt-get -y --purge autoremove; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*;
+
 EXPOSE 80
 VOLUME /data
 WORKDIR /data

--- a/Dockerfile_light
+++ b/Dockerfile_light
@@ -3,10 +3,10 @@ FROM ubuntu:focal
 ENV \
     NODE_ENV="production" \
     CHOKIDAR_USEPOLLING=1 \
-    CHOKIDAR_INTERVAL=500 \
-    DEBIAN_FRONTEND=noninteractive
+    CHOKIDAR_INTERVAL=500
 
 RUN set -ex; \
+    export DEBIAN_FRONTEND=noninteractive; \
     groupadd -r node; \
     useradd -r -g node node; \
     apt-get -qq update; \

--- a/Dockerfile_light
+++ b/Dockerfile_light
@@ -1,4 +1,17 @@
-FROM node:16-bullseye
+FROM ubuntu:focal
+
+RUN export DEBIAN_FRONTEND=noninteractive \
+  && apt-get -qq update \
+  && apt-get -y --no-install-recommends install \
+      ca-certificates \
+      wget \
+  && apt-get -y --purge autoremove \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+  
+RUN wget -qO- https://deb.nodesource.com/setup_16.x | bash
+RUN apt-get install -y nodejs
+RUN groupadd -r node && useradd -r -g node node
 
 ENV NODE_ENV="production"
 ENV CHOKIDAR_USEPOLLING=1
@@ -12,3 +25,4 @@ RUN mkdir -p /usr/src/app
 COPY / /usr/src/app
 RUN cd /usr/src/app && npm install --production
 RUN ["chmod", "+x", "/usr/src/app/docker-entrypoint.sh"]
+USER node:node

--- a/Dockerfile_test
+++ b/Dockerfile_test
@@ -10,6 +10,7 @@ RUN set -ex; \
     export DEBIAN_FRONTEND=noninteractive; \
     apt-get -qq update; \
     apt-get -y --no-install-recommends install \
+      unzip \
       build-essential \
       ca-certificates \
       wget \

--- a/Dockerfile_test
+++ b/Dockerfile_test
@@ -32,5 +32,4 @@ ENV NODE_ENV="test"
 COPY package.json .
 RUN npm install
 COPY . .
-RUN ls
 RUN xvfb-run --server-args="-screen 0 1024x768x24" npm test

--- a/Dockerfile_test
+++ b/Dockerfile_test
@@ -31,5 +31,6 @@ ENV NODE_ENV="test"
 
 COPY package.json .
 RUN npm install
-COPY . .
+COPY / .
+
 RUN xvfb-run --server-args="-screen 0 1024x768x24" npm test

--- a/Dockerfile_test
+++ b/Dockerfile_test
@@ -4,11 +4,10 @@
 
 FROM ubuntu:focal
 
-ENV \
-    NODE_ENV="test" \
-    DEBIAN_FRONTEND=noninteractive
+ENV NODE_ENV="production"
 
 RUN set -ex; \
+    export DEBIAN_FRONTEND=noninteractive; \
     apt-get -qq update; \
     apt-get -y --no-install-recommends install \
       ca-certificates \

--- a/Dockerfile_test
+++ b/Dockerfile_test
@@ -2,24 +2,24 @@
 # Simply run "docker build -f Dockerfile_test ."
 # WARNING: sometimes it fails with a core dumped exception
 
-FROM node:16-bullseye
+FROM ubuntu:focal
 
 RUN apt-get -qq update \
 && DEBIAN_FRONTEND=noninteractive apt-get -y install \
-    apt-transport-https \
-    curl \
-    unzip \
-    build-essential \
-    python \
-    libcairo2-dev \
-    libgles2-mesa-dev \
-    libgbm-dev \
-    libllvm3.9 \
-    libprotobuf-dev \
-    libxxf86vm-dev \
-    libopengl0 \
-    xvfb \
+      ca-certificates \	
+      wget \
+      pkg-config \
+      xvfb \
+      libglfw3-dev \
+      libuv1-dev \
+      libjpeg-turbo8 \
+      libicu66 \
+      unzip \
+      libcurl4-openssl-dev \
 && apt-get clean
+
+RUN wget -qO- https://deb.nodesource.com/setup_16.x | bash
+RUN apt-get install -y nodejs
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
@@ -31,5 +31,6 @@ ENV NODE_ENV="test"
 
 COPY package.json .
 RUN npm install
-COPY / .
+COPY . .
+RUN ls
 RUN xvfb-run --server-args="-screen 0 1024x768x24" npm test

--- a/Dockerfile_test
+++ b/Dockerfile_test
@@ -4,9 +4,14 @@
 
 FROM ubuntu:focal
 
-RUN apt-get -qq update \
-&& DEBIAN_FRONTEND=noninteractive apt-get -y install \
-      ca-certificates \	
+ENV \
+    NODE_ENV="test" \
+    DEBIAN_FRONTEND=noninteractive
+
+RUN set -ex; \
+    apt-get -qq update; \
+    apt-get -y --no-install-recommends install \
+      ca-certificates \
       wget \
       pkg-config \
       xvfb \
@@ -15,19 +20,16 @@ RUN apt-get -qq update \
       libjpeg-turbo8 \
       libicu66 \
       unzip \
-      libcurl4-openssl-dev \
-&& apt-get clean
-
-RUN wget -qO- https://deb.nodesource.com/setup_16.x | bash
-RUN apt-get install -y nodejs
+      libcurl4-openssl-dev; \
+    wget -qO- https://deb.nodesource.com/setup_16.x | bash; \
+    apt-get install -y nodejs; \
+    apt-get clean;
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-RUN wget -O test_data.zip https://github.com/maptiler/tileserver-gl/releases/download/v1.3.0/test_data.zip
-RUN unzip -q test_data.zip -d test_data
-
-ENV NODE_ENV="test"
+RUN wget -O test_data.zip https://github.com/maptiler/tileserver-gl/releases/download/v1.3.0/test_data.zip; \
+    unzip -q test_data.zip -d test_data
 
 COPY package.json .
 RUN npm install

--- a/Dockerfile_test
+++ b/Dockerfile_test
@@ -10,6 +10,7 @@ RUN set -ex; \
     export DEBIAN_FRONTEND=noninteractive; \
     apt-get -qq update; \
     apt-get -y --no-install-recommends install \
+      build-essential \
       ca-certificates \
       wget \
       pkg-config \
@@ -18,8 +19,13 @@ RUN set -ex; \
       libuv1-dev \
       libjpeg-turbo8 \
       libicu66 \
-      unzip \
-      libcurl4-openssl-dev; \
+      libcairo2-dev \
+      libpango1.0-dev \
+      libjpeg-dev \
+      libgif-dev \
+      librsvg2-dev \
+      libcurl4-openssl-dev \
+      libpixman-1-dev; \
     wget -qO- https://deb.nodesource.com/setup_16.x | bash; \
     apt-get install -y nodejs; \
     apt-get clean;

--- a/Dockerfile_test
+++ b/Dockerfile_test
@@ -4,7 +4,7 @@
 
 FROM ubuntu:focal
 
-ENV NODE_ENV="production"
+ENV NODE_ENV="development"
 
 RUN set -ex; \
     export DEBIAN_FRONTEND=noninteractive; \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -20,7 +20,7 @@ trap refresh HUP
 
 if ! which -- "${1}"; then
   # first arg is not an executable
-  xvfb-run -a --server-args="-screen 0 1024x768x24" -- node /app/ -p 80 "$@" &
+  xvfb-run -a --server-args="-screen 0 1024x768x24" -- node /usr/src/app/ -p 80 "$@" &
 	# Wait exits immediately on signals which have traps set. Store return value and wait
 	# again for all jobs to actually complete before continuing.
 	wait $! || RETVAL=$?


### PR DESCRIPTION
This moves the docker images from a node debian image to an ubuntu image. This makes it so libjpeg-turbo8 and libicu66 don't have to be sideloaded into debian to get it to work with maplibre-native. 

Due to no longer using a node image, I had to install my own node. I decided to use nodesource since it seems to be a recommended way by [nodejs.org](https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions)

The original image ran as a node user, which is recommended for security. I tried to do the same in these images, but I had to make the users and group since they do not exist by default.