### PR TITLE
Simplify canvas import in serve_rendered.js

### DIFF
--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -7,7 +7,7 @@ import url from 'url';
 import util from 'util';
 import zlib from 'zlib';
 import sharp from 'sharp'; // sharp has to be required before node-canvas. see https://github.com/lovell/sharp/issues/371
-import pkg from 'canvas';
+import {createCanvas, Image} from 'canvas';
 import clone from 'clone';
 import Color from 'color';
 import express from 'express';
@@ -22,7 +22,6 @@ import {getFontsPbf, getTileUrls, fixTileJSONCenter} from './utils.js';
 const FLOAT_PATTERN = '[+-]?(?:\\d+|\\d+\.?\\d+)';
 const httpTester = /^(http(s)?:)?\/\//;
 
-const {createCanvas, Image} = pkg;
 const mercator = new SphericalMercator();
 const getScale = (scale) => (scale || '@1x').slice(1, 2) | 0;
 


### PR DESCRIPTION
I meant to simplify this canvas import before https://github.com/maptiler/tileserver-gl/pull/606 was merged, but it got missed. 