### PR TITLE
chown /data volume in Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,6 +72,7 @@ COPY --from=builder /usr/src/app /usr/src/app
 
 COPY . /usr/src/app
 
+RUN mkdir -p /data && chown node:node /data
 VOLUME /data
 WORKDIR /data
 

--- a/Dockerfile_light
+++ b/Dockerfile_light
@@ -21,6 +21,8 @@ RUN set -ex; \
     rm -rf /var/lib/apt/lists/*;
 
 EXPOSE 80
+
+RUN mkdir -p /data && chown node:node /data
 VOLUME /data
 WORKDIR /data
 ENTRYPOINT ["/usr/src/app/docker-entrypoint.sh"]


### PR DESCRIPTION
Currently, if we run the container without mounting a volume, it fails with the following as /data is owned by root:

```
docker run --rm --pull always maptiler/tileserver-gl
latest: Pulling from maptiler/tileserver-gl
Digest: sha256:6bc09421fca44ef603ba174eb7b3e988464a73423ec56126fd3e771d4db370a8
Status: Image is up to date for maptiler/tileserver-gl:latest
Starting tileserver-gl v4.1.2
No MBTiles found
[DEMO] Downloading sample data (zurich_switzerland.mbtiles) from https://github.com/maptiler/tileserver-gl/releases/download/v1.3.0/zurich_switzerland.mbtiles
node:events:491
      throw er; // Unhandled 'error' event
      ^

Error: EACCES: permission denied, open 'zurich_switzerland.mbtiles'
Emitted 'error' event on WriteStream instance at:
    at WriteStream.onerror (node:internal/streams/legacy:62:12)
    at WriteStream.emit (node:events:513:28)
    at emitErrorNT (node:internal/streams/destroy:157:8)
    at emitErrorCloseNT (node:internal/streams/destroy:122:3)
    at processTicksAndRejections (node:internal/process/task_queues:83:21) {
  errno: -13,
  code: 'EACCES',
  syscall: 'open',
  path: 'zurich_switzerland.mbtiles'
}
```