### PR TITLE
change docker to use port 8080 by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,7 @@ RUN mkdir -p /data && chown node:node /data
 VOLUME /data
 WORKDIR /data
 
-EXPOSE 80
+EXPOSE 8080
 
 USER node:node
 

--- a/Dockerfile_light
+++ b/Dockerfile_light
@@ -20,7 +20,7 @@ RUN set -ex; \
     apt-get clean; \
     rm -rf /var/lib/apt/lists/*;
 
-EXPOSE 80
+EXPOSE 8080
 
 RUN mkdir -p /data && chown node:node /data
 VOLUME /data

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ An alternative to npm to start the packed software easier is to install [Docker]
 Example using a mbtiles file
 ```bash
 wget https://github.com/maptiler/tileserver-gl/releases/download/v1.3.0/zurich_switzerland.mbtiles
-docker run --rm -it -v $(pwd):/data -p 8080:80 maptiler/tileserver-gl --mbtiles zurich_switzerland.mbtiles
+docker run --rm -it -v $(pwd):/data -p 8080:8080 maptiler/tileserver-gl --mbtiles zurich_switzerland.mbtiles
 [in your browser, visit http://[server ip]:8080]
 ```
 
@@ -52,13 +52,13 @@ Example using a config.json + style + mbtiles file
 ```bash
 wget https://github.com/maptiler/tileserver-gl/releases/download/v1.3.0/test_data.zip
 unzip test_data.zip
-docker run --rm -it -v $(pwd):/data -p 8080:80 maptiler/tileserver-gl
+docker run --rm -it -v $(pwd):/data -p 8080:8080 maptiler/tileserver-gl
 [in your browser, visit http://[server ip]:8080]
 ```
 
 Example using a different path
 ```bash
-docker run --rm -it -v /your/local/config/path:/data -p 8080:80 maptiler/tileserver-gl
+docker run --rm -it -v /your/local/config/path:/data -p 8080:8080 maptiler/tileserver-gl
 ```
 replace '/your/local/config/path' with the path to your config file
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -20,7 +20,7 @@ trap refresh HUP
 
 if ! which -- "${1}"; then
   # first arg is not an executable
-  xvfb-run -a --server-args="-screen 0 1024x768x24" -- node /usr/src/app/ -p 80 "$@" &
+  xvfb-run -a --server-args="-screen 0 1024x768x24" -- node /usr/src/app/ "$@" &
 	# Wait exits immediately on signals which have traps set. Store return value and wait
 	# again for all jobs to actually complete before continuing.
 	wait $! || RETVAL=$?

--- a/docker-entrypoint_light.sh
+++ b/docker-entrypoint_light.sh
@@ -20,7 +20,7 @@ trap refresh HUP
 
 if ! which -- "${1}"; then
   # first arg is not an executable
-  node /usr/src/app/ -p 80 "$@" &
+  node /usr/src/app/ "$@" &
 	# Wait exits immediately on signals which have traps set. Store return value and wait
 	# again for all jobs to actually complete before continuing.
 	wait $! || RETVAL=$?

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -7,7 +7,7 @@ Docker
 
 When running docker image, no special installation is needed -- the docker will automatically download the image if not present.
 
-Just run ``docker run --rm -it -v $(pwd):/data -p 8080:80 maptiler/tileserver-gl``.
+Just run ``docker run --rm -it -v $(pwd):/data -p 8080:8080 maptiler/tileserver-gl``.
 
 Additional options (see :doc:`/usage`) can be passed to the TileServer GL by appending them to the end of this command. You can, for example, do the following:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tileserver-gl",
-  "version": "4.1.3",
+  "version": "4.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tileserver-gl",
-      "version": "4.1.3",
+      "version": "4.2.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@mapbox/glyph-pbf-composite": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tileserver-gl",
-  "version": "4.1.3",
+  "version": "4.2.0",
   "description": "Map tile server for JSON GL styles - vector and server side generated raster tiles",
   "main": "src/main.js",
   "bin": "src/main.js",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "test": "mocha test/**.js --timeout 10000",
-    "docker": "docker build -f Dockerfile . && docker run --rm -i -p 8080:80 $(docker build -q .)"
+    "docker": "docker build -f Dockerfile . && docker run --rm -i -p 8080:8080 $(docker build -q .)"
   },
   "dependencies": {
     "@mapbox/glyph-pbf-composite": "0.0.3",

--- a/run.sh
+++ b/run.sh
@@ -29,7 +29,7 @@ export DISPLAY=:${displayNumber}.${screenNumber}
 
 echo
 cd /data
-node /usr/src/app/ -p 80 "$@" &
+node /usr/src/app/ "$@" &
 child=$!
 wait "$child"
 

--- a/src/healthcheck.js
+++ b/src/healthcheck.js
@@ -2,7 +2,7 @@ import * as http from 'http';
 var options = {
   timeout: 2000,
 };
-var url = "http://localhost:80/health";
+var url = "http://localhost:8080/health";
 var request = http.request(url, options, (res) => {
   console.log(`STATUS: ${res.statusCode}`);
   if (res.statusCode == 200) {


### PR DESCRIPTION
This PR moves the docker images to use the default 8080 port and updates all the documentation. Opening on port 80 usually requires root access, so moving it to port 8080 makes it easier to start as a non-root user.  I think it also makes it visually easier to understand, since the prompt "Listening at http://[::]:8080/" will actually match the port the user needs to go to to access the server.

There are several issues and PRs that would be helped by moving the default port to 8080, ex
https://github.com/maptiler/tileserver-gl/issues/573
https://github.com/maptiler/tileserver-gl/pull/578
https://github.com/maptiler/tileserver-gl/issues/503


My only concern with this is it is somewhat of a breaking change for users expecting the docker to start on port 80, but I think this will be better off on a higher port.