### PR TITLE
fix: Ensure font serving does not reflect userdata-derived errors as HTML

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tileserver-gl",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tileserver-gl",
-      "version": "4.2.0",
+      "version": "4.2.1",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@mapbox/glyph-pbf-composite": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tileserver-gl",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "Map tile server for JSON GL styles - vector and server side generated raster tiles",
   "main": "src/main.js",
   "bin": "src/main.js",

--- a/src/serve_data.js
+++ b/src/serve_data.js
@@ -54,7 +54,10 @@ export const serve_data = {
             if (/does not exist/.test(err.message)) {
               return res.status(204).send();
             } else {
-              return res.status(500).send(err.message);
+              return res
+                .status(500)
+                .header('Content-Type', 'text/plain')
+                .send(err.message);
             }
           } else {
             if (data == null) {

--- a/src/serve_font.js
+++ b/src/serve_font.js
@@ -54,7 +54,7 @@ export const serve_font = (options, allowedFonts) => {
         res.header('Last-Modified', lastModified);
         return res.send(concated);
       },
-      (err) => res.status(400).send(err),
+      (err) => res.status(400).header('Content-Type', 'text/plain').send(err),
     );
   });
 

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -661,7 +661,10 @@ export const serve_rendered = {
           pool.release(renderer);
           if (err) {
             console.error(err);
-            return res.status(500).send(err);
+            return res
+              .status(500)
+              .header('Content-Type', 'text/plain')
+              .send(err);
           }
 
           // Fix semi-transparent outlines on raw, premultiplied input


### PR DESCRIPTION
Fixes https://github.com/maptiler/tileserver-gl/issues/642.

The issue is that if we could not find a font stack, we were rejecting with an error that included the passed fontstack name. We then sent that error back to the user as plaintext, but in not setting a `content-type` header, browsers guess the response is html and would try to render the fontstack name as html.

I audited the rest of the codebase to find other places where we might potentially reflect back user-supplied data and changed those to always set `content-type: text/plain`. I'd also be amenable to _always_ setting `content-type: text/plain` for any response that is not json and is not explicitly trying to render some other format.