### PR TITLE
update to new maplibre with linux arm64 binary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@mapbox/mbtiles": "0.12.1",
         "@mapbox/sphericalmercator": "1.2.0",
         "@mapbox/vector-tile": "1.3.1",
-        "@maplibre/maplibre-gl-native": "5.0.1-pre.6",
+        "@maplibre/maplibre-gl-native": "5.1.0-pre.1",
         "@maplibre/maplibre-gl-style-spec": "17.0.1",
         "advanced-pool": "0.3.3",
         "canvas": "2.10.2",
@@ -907,9 +907,9 @@
       }
     },
     "node_modules/@maplibre/maplibre-gl-native": {
-      "version": "5.0.1-pre.6",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-native/-/maplibre-gl-native-5.0.1-pre.6.tgz",
-      "integrity": "sha512-uDjrNdsnwWqM1KoCNnEHoBM5zpCIQ/iV7K0kDMd7ds0xb0mzcW8b8Fz3ApyVYrHEJXBVONjgwpv46I6DtSfLcQ==",
+      "version": "5.1.0-pre.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-native/-/maplibre-gl-native-5.1.0-pre.1.tgz",
+      "integrity": "sha512-m4HTUhKmMWiTolNRPwdSP62+0ixZO34sE5zFMrDAocpeDH3Er55tTbSZci+1Q/HGzamPf2gq75ZPPMrfOJn9tA==",
       "hasInstallScript": true,
       "dependencies": {
         "@acalcutt/node-pre-gyp": "^1.0.11",
@@ -9605,9 +9605,9 @@
       }
     },
     "@maplibre/maplibre-gl-native": {
-      "version": "5.0.1-pre.6",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-native/-/maplibre-gl-native-5.0.1-pre.6.tgz",
-      "integrity": "sha512-uDjrNdsnwWqM1KoCNnEHoBM5zpCIQ/iV7K0kDMd7ds0xb0mzcW8b8Fz3ApyVYrHEJXBVONjgwpv46I6DtSfLcQ==",
+      "version": "5.1.0-pre.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-native/-/maplibre-gl-native-5.1.0-pre.1.tgz",
+      "integrity": "sha512-m4HTUhKmMWiTolNRPwdSP62+0ixZO34sE5zFMrDAocpeDH3Er55tTbSZci+1Q/HGzamPf2gq75ZPPMrfOJn9tA==",
       "requires": {
         "@acalcutt/node-pre-gyp": "^1.0.11",
         "@acalcutt/node-pre-gyp-github": "1.4.8",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@mapbox/mbtiles": "0.12.1",
     "@mapbox/sphericalmercator": "1.2.0",
     "@mapbox/vector-tile": "1.3.1",
-    "@maplibre/maplibre-gl-native": "5.0.1-pre.6",
+    "@maplibre/maplibre-gl-native": "5.1.0-pre.1",
     "@maplibre/maplibre-gl-style-spec": "17.0.1",
     "advanced-pool": "0.3.3",
     "canvas": "2.10.2",


### PR DESCRIPTION
This moves to the newly published maplibre-gl-native": "5.1.0-pre.1", which adds a linux (ubuntu 20.04) arm64 binary. This should allow us to make a arm64 docker build.