### PR TITLE
add back missing PACKAGE_VERSION

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,10 +37,6 @@ jobs:
           check-latest: true
           cache: 'npm'
 
-      - name: Get version
-        run: |
-          echo "PACKAGE_VERSION=$(grep '"version"' package.json | cut -d '"' -f 4 | head -n 1)" >> $GITHUB_ENV
-
       - name: Install dependencies 🚀
         run: npm ci --prefer-offline --no-audit --omit=optional
 
@@ -64,6 +60,10 @@ jobs:
           npm publish --access public
         env:
           NPM_TOKEN: ${{ github.event.inputs.npm_token }}
+
+      - name: Get version
+        run: |
+          echo "PACKAGE_VERSION=$(grep '"version"' package.json | cut -d '"' -f 4 | head -n 1)" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,10 @@ jobs:
           check-latest: true
           cache: 'npm'
 
+      - name: Get version
+        run: |
+          echo "PACKAGE_VERSION=$(grep '"version"' package.json | cut -d '"' -f 4 | head -n 1)" >> $GITHUB_ENV
+
       - name: Install dependencies 🚀
         run: npm ci --prefer-offline --no-audit --omit=optional
 


### PR DESCRIPTION
This code to get the package version was accidently omitted from the workflow. This is needed right now to get the version for the docker publish.

I would like to replace this with a automated version bump eventually, but for now this in needed