### PR TITLE
chore: Use Ubuntu 22.04 instead of 20.04 on the GitHub Actions

### DIFF
--- a/.github/workflows/ct.yml
+++ b/.github/workflows/ct.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   ct:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repository ✨ (non-dependabot)
         if: ${{ github.actor != 'dependabot[bot]' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   release:
     name: "Build, Test, Publish"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repository ✨
         uses: actions/checkout@v3


### PR DESCRIPTION
I suggest using Ubuntu 22.04 instead of Ubuntu 20.04 on the GitHub Actions workflows.

This pull request is very simple, please check code diffs.

If you are intentionally using Ubuntu 20.04, I apologize.