### PR TITLE
allow tileMargin option

### DIFF
--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -634,7 +634,7 @@ export const serve_rendered = {
 
       const tileMargin = Math.max(options.tileMargin || 0, 0);
       let pool;
-      if (opt_mode === 'tile'&& tileMargin === 0) {
+      if (opt_mode === 'tile' && tileMargin === 0) {
         pool = item.map.renderers[scale];
       } else {
         pool = item.map.renderers_static[scale];

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -615,6 +615,7 @@ export const serve_rendered = {
       ) {
         return res.status(400).send('Invalid center');
       }
+
       if (
         Math.min(width, height) <= 0 ||
         Math.max(width, height) * scale > (options.maxSize || 2048) ||
@@ -623,6 +624,7 @@ export const serve_rendered = {
       ) {
         return res.status(400).send('Invalid size');
       }
+
       if (format === 'png' || format === 'webp') {
       } else if (format === 'jpg' || format === 'jpeg') {
         format = 'jpeg';
@@ -630,8 +632,9 @@ export const serve_rendered = {
         return res.status(400).send('Invalid format');
       }
 
+      const tileMargin = Math.max(options.tileMargin || 0, 0);
       let pool;
-      if (opt_mode === 'tile') {
+      if (opt_mode === 'tile'&& tileMargin === 0) {
         pool = item.map.renderers[scale];
       } else {
         pool = item.map.renderers_static[scale];
@@ -646,12 +649,12 @@ export const serve_rendered = {
           width: width,
           height: height,
         };
+
         if (z === 0) {
           params.width *= 2;
           params.height *= 2;
         }
 
-        const tileMargin = Math.max(options.tileMargin || 0, 0);
         if (z > 2 && tileMargin > 0) {
           params.width += tileMargin * 2;
           params.height += tileMargin * 2;


### PR DESCRIPTION
Fix for https://github.com/maptiler/tileserver-gl/issues/649

In maplibre-native there has been code added which limits maps in 'tile mode' to a single tile. This means the TileMargin option does not work because it extends beyond a single tile.  This change forces tileserver to use the static renderer when TileMargin is set. This allows maplibre-native to render beyond the single tile and allows TileMargin to work

For example, without this change, a file generated by tilemaker has labels clipped like
![image](https://user-images.githubusercontent.com/3792408/210303125-63984eee-96ac-4a04-8841-978d61d9c994.png)

After this change, and setting TileMargin to 10, it looks like this
![image](https://user-images.githubusercontent.com/3792408/210303064-9f1b388a-7bba-49fa-9af5-230be9d40110.png)
