### PR TITLE
Update to node 18, add docker build test

### DIFF
--- a/.github/workflows/ct.yml
+++ b/.github/workflows/ct.yml
@@ -55,3 +55,18 @@ jobs:
 
       - name: Run tests 🧪
         run: xvfb-run --server-args="-screen 0 1024x768x24" npm test
+        
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: 'arm64'
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        
+      - name: Test Docker Build
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: false
+          platforms: linux/arm64,linux/amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN set -ex; \
       librsvg2-dev \
       libcurl4-openssl-dev \
       libpixman-1-dev; \
-    wget -qO- https://deb.nodesource.com/setup_16.x | bash; \
+    wget -qO- https://deb.nodesource.com/setup_18.x | bash; \
     apt-get install -y nodejs; \
     apt-get -y remove wget; \
     apt-get -y --purge autoremove; \
@@ -61,7 +61,7 @@ RUN set -ex; \
       libcurl4 \
       librsvg2-2 \
       libpango1.0; \
-    wget -qO- https://deb.nodesource.com/setup_16.x | bash; \
+    wget -qO- https://deb.nodesource.com/setup_18.x | bash; \
     apt-get install -y nodejs; \
     apt-get -y remove wget; \
     apt-get -y --purge autoremove; \

--- a/Dockerfile_light
+++ b/Dockerfile_light
@@ -13,7 +13,7 @@ RUN set -ex; \
     apt-get -y --no-install-recommends install \
       ca-certificates \
       wget; \
-    wget -qO- https://deb.nodesource.com/setup_16.x | bash; \
+    wget -qO- https://deb.nodesource.com/setup_18.x | bash; \
     apt-get install -y nodejs; \
     apt-get -y remove wget; \
     apt-get -y --purge autoremove; \

--- a/Dockerfile_test
+++ b/Dockerfile_test
@@ -27,7 +27,7 @@ RUN set -ex; \
       librsvg2-dev \
       libcurl4-openssl-dev \
       libpixman-1-dev; \
-    wget -qO- https://deb.nodesource.com/setup_16.x | bash; \
+    wget -qO- https://deb.nodesource.com/setup_18.x | bash; \
     apt-get install -y nodejs; \
     apt-get clean;
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Vector and raster maps with GL styles. Server-side rendering by MapLibre GL Nati
 Download vector tiles from [OpenMapTiles](https://data.maptiler.com/downloads/planet/).
 ## Getting Started with Node
 
-Make sure you have Node.js version **14.20.0** or above installed. Node 16 is recommended. (running `node -v` it should output something like `v16.x.x`). Running without docker requires [Native dependencies](https://tileserver.readthedocs.io/en/latest/installation.html#npm) to be installed first.
+Make sure you have Node.js version **14.20.0** or above installed. Node 18 is recommended. (running `node -v` it should output something like `v18.x.x`). Running without docker requires [Native dependencies](https://tileserver.readthedocs.io/en/latest/installation.html#npm) to be installed first.
 
 Install `tileserver-gl` with server-side raster rendering of vector tiles with npm. 
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Vector and raster maps with GL styles. Server-side rendering by MapLibre GL Nati
 Download vector tiles from [OpenMapTiles](https://data.maptiler.com/downloads/planet/).
 ## Getting Started with Node
 
-Make sure you have Node.js version **14.20.0** or above installed. Node 18 is recommended. (running `node -v` it should output something like `v18.x.x`). Running without docker requires [Native dependencies](https://tileserver.readthedocs.io/en/latest/installation.html#npm) to be installed first.
+Make sure you have Node.js version **14.20.0** or above installed. Node 18 is recommended. (running `node -v` it should output something like `v18.x.x`). Running without docker requires [Native dependencies](https://maptiler-tileserver.readthedocs.io/en/latest/installation.html#npm) to be installed first.
 
 Install `tileserver-gl` with server-side raster rendering of vector tiles with npm. 
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -60,7 +60,7 @@ Alternatively, you can use ``tileserver-gl-light`` package instead, which is pur
 From source
 ===========
 
-Make sure you have Node v10 (nvm install 10) and run::
+Make sure you have Node v18 (nvm install 18) and run::
 
   npm install
   node .

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   ],
   "license": "BSD-2-Clause",
   "engines": {
-    "node": ">=14.15.0 <19"
+    "node": ">=14.20.0 <19"
   },
   "repository": {
     "url": "git+https://github.com/maptiler/tileserver-gl.git",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   ],
   "license": "BSD-2-Clause",
   "engines": {
-    "node": ">=14.15.0 <17"
+    "node": ">=14.15.0 <19"
   },
   "repository": {
     "url": "git+https://github.com/maptiler/tileserver-gl.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tileserver-gl",
-  "version": "4.3.4",
+  "version": "4.4.0",
   "description": "Map tile server for JSON GL styles - vector and server side generated raster tiles",
   "main": "src/main.js",
   "bin": "src/main.js",


### PR DESCRIPTION
This PR raises the recommended node version to 18.  I had tested moving to node 18 a while back, but at the time it did not work (I think due to canvas). I tested again today and it seems to work now.  If it works I think it makes sense to raise the default node we recommend, since Node 18 is supported form much longer than Node 16 (2y vs 6m).

I have also added a docker build to the ct test, so it is possible to see if changes like this work on both x64 and arm64.