### PR TITLE
fix: fix vectortile constructor

### DIFF
--- a/src/serve_data.js
+++ b/src/serve_data.js
@@ -8,7 +8,7 @@ import clone from 'clone';
 import express from 'express';
 import MBTiles from '@mapbox/mbtiles';
 import Pbf from 'pbf';
-import VectorTile from '@mapbox/vector-tile';
+import { VectorTile } from '@mapbox/vector-tile';
 
 import { getTileUrls, fixTileJSONCenter } from './utils.js';
 


### PR DESCRIPTION
When requesting a `geojson` tile as specified in the tile with URL such as:

```
http://localhost:8080/data/v3/10/511/513.geojson
```

tileserver-gl currently throws:

```
file:///Users/danielkao/Repos/tileserver-gl/src/serve_data.js:87
                const tile = new VectorTile(new Pbf(data));
                             ^

TypeError: VectorTile is not a constructor
    at file:///Users/danielkao/Repos/tileserver-gl/src/serve_data.js:87:30
    at Statement.<anonymous> (/Users/danielkao/Repos/tileserver-gl/node_modules/@mapbox/mbtiles/lib/mbtiles.js:196:20)

Node.js v18.13.0
```

I did a little digging and realized that `VectorTile` was not being imported correctly. This fixes it.

Signed-off-by: Daniel Kao <dkao@diplateevo.com>