### PR TITLE
fix: support for `X-Forwarded-Host` http header

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -6,8 +6,8 @@ import fs from 'node:fs';
 import clone from 'clone';
 import glyphCompose from '@mapbox/glyph-pbf-composite';
 
-const getUrlObject = (urlString, req) => {
-  const urlObject = new URL(urlString);
+const getUrlObject = (req) => {
+  const urlObject = new URL(`${req.protocol}://${req.headers.host}/`);
   // support overriding hostname by sending X-Forwarded-Host http header
   urlObject.hostname = req.hostname;
 
@@ -19,12 +19,12 @@ export const getPublicUrl = (publicUrl, req) => {
     return publicUrl;
   }
 
-  const urlObject = getUrlObject(`${req.protocol}://${req.headers.host}/`, req);
+  const urlObject = getUrlObject(req);
   return urlObject.toString();
 };
 
 export const getTileUrls = (req, domains, path, format, publicUrl, aliases) => {
-  const urlObject = getUrlObject(`${req.protocol}://${req.headers.host}/`, req);
+  const urlObject = getUrlObject(req);
   const host = urlObject.host;
 
   if (domains) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,11 +6,15 @@ import fs from 'node:fs';
 import clone from 'clone';
 import glyphCompose from '@mapbox/glyph-pbf-composite';
 
+/**
+* Generate new URL object
+* @params {object} req - Express request
+* @returns {URL} object
+**/
 const getUrlObject = (req) => {
   const urlObject = new URL(`${req.protocol}://${req.headers.host}/`);
   // support overriding hostname by sending X-Forwarded-Host http header
   urlObject.hostname = req.hostname;
-
   return urlObject;
 };
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -50,7 +50,7 @@ export const getTileUrls = (req, domains, path, format, publicUrl, aliases) => {
     domains = newDomains;
   }
   if (!domains || domains.length == 0) {
-    domains = [host];
+    domains = [urlObject.host];
   }
 
   const queryParams = [];

--- a/src/utils.js
+++ b/src/utils.js
@@ -27,8 +27,6 @@ export const getPublicUrl = (publicUrl, req) => {
 
 export const getTileUrls = (req, domains, path, format, publicUrl, aliases) => {
   const urlObject = getUrlObject(req);
-  const host = urlObject.host;
-
   if (domains) {
     if (domains.constructor === String && domains.length > 0) {
       domains = domains.split(',');

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,10 +7,10 @@ import clone from 'clone';
 import glyphCompose from '@mapbox/glyph-pbf-composite';
 
 /**
-* Generate new URL object
-* @params {object} req - Express request
-* @returns {URL} object
-**/
+ * Generate new URL object
+ * @params {object} req - Express request
+ * @returns {URL} object
+ **/
 const getUrlObject = (req) => {
   const urlObject = new URL(`${req.protocol}://${req.headers.host}/`);
   // support overriding hostname by sending X-Forwarded-Host http header
@@ -31,10 +31,10 @@ export const getTileUrls = (req, domains, path, format, publicUrl, aliases) => {
     if (domains.constructor === String && domains.length > 0) {
       domains = domains.split(',');
     }
-    const hostParts = host.split('.');
+    const hostParts = urlObject.host.split('.');
     const relativeSubdomainsUsable =
       hostParts.length > 1 &&
-      !/^([0-9]{1,3}\.){3}[0-9]{1,3}(\:[0-9]+)?$/.test(host);
+      !/^([0-9]{1,3}\.){3}[0-9]{1,3}(\:[0-9]+)?$/.test(urlObject.host);
     const newDomains = [];
     for (const domain of domains) {
       if (domain.indexOf('*') !== -1) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -22,9 +22,7 @@ export const getPublicUrl = (publicUrl, req) => {
   if (publicUrl) {
     return publicUrl;
   }
-
-  const urlObject = getUrlObject(req);
-  return urlObject.toString();
+  return getUrlObject(req).toString();
 };
 
 export const getTileUrls = (req, domains, path, format, publicUrl, aliases) => {


### PR DESCRIPTION
This PR fixes support for overriding the hostname by sending `X-Forwarded-Host` http header. 
- Resolves https://github.com/maptiler/tileserver-gl/pull/273 and https://github.com/maptiler/tileserver-gl/issues/119

This implementation preserves the port information, which is necessary for local development and production deployment which use a port other than 80. This was the only issue which prevented the PR above to be merged.

Signed-off-by: Manuel Roth <manuelroth@hotmail.ch>