### PR TITLE
Update license from mapbox to maplibre

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,5 @@
-TileServer GL
-=============
+## [TileServer GL](https://github.com/maptiler/tileserver-gl)
+```
 Copyright (c) 2023, MapTiler.com
 Copyright (c) 2016, Klokan Technologies GmbH
 
@@ -27,7 +27,7 @@ PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
 LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
+```
 ===========================================================================
 
 ### [MapLibre-GL-Native](https://github.com/maplibre/maplibre-gl-native)

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -30,8 +30,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ===========================================================================
 
-MapLibre-GL-Native - BSD 2-Clause License
-
+### [MapLibre-GL-Native](https://github.com/maplibre/maplibre-gl-native)
+```
+BSD 2-Clause License
 Copyright (c) 2021 MapLibre contributors
 Copyright (c) 2018-2021 MapTiler.com
 Copyright (c) 2014-2020 Mapbox
@@ -58,128 +59,157 @@ PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
 LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
 
 ===========================================================================
 
-MapLibre-GL-Native uses portions of Android Gesture Detectors Framework.
+### [kdbush.hpp](https://github.com/mourner/kdbush.hpp) by Vladimir Agafonkin
 
-Copyright (c) 2012, Almer Thie
+```
+Copyright (c) 2016, Vladimir Agafonkin
 
-All rights reserved.
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
+```
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+---
 
-===========================================================================
+### [supercluster.hpp](https://github.com/mapbox/supercluster.hpp) by Mapbox
 
-MapLibre-GL-Native uses portions of Android Support Library.
+```
+Copyright (c) 2016, Mapbox
 
-Copyright (c) 2005-2013, The Android Open Source Project
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-http://www.apache.org/licenses/LICENSE-2.0
+```
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+---
 
-===========================================================================
+### [shelf-pack-cpp](https://github.com/mapbox/shelf-pack-cpp) by Mapbox
 
-MapLibre-GL-Native uses portions of Boost.
+```
+ISC License
 
-Distributed under the Boost Software License, Version 1.0.
+Copyright (c) 2017, Mapbox
 
-http://www.boost.org/LICENSE_1_0.txt
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
 
-===========================================================================
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.
 
-MapLibre-GL-Native uses portions of Clipper.
+```
 
-Author    :  Angus Johnson
-Version   :  6.1.3a
-Date      :  22 January 2014
-Website   :  http://www.angusj.com
-Copyright :  Angus Johnson 2010-2014
+---
 
-License:
-Use, modification & distribution is subject to Boost Software License Ver 1.
-http://www.boost.org/LICENSE_1_0.txt
+### [geojson-vt-cpp](https://github.com/mapbox/geojson-vt-cpp) by Mapbox
 
-Attributions:
-The code in this library is an extension of Bala Vatti's clipping algorithm:
-"A generic solution to polygon clipping"
-Communications of the ACM, Vol 35, Issue 7 (July 1992) pp 56-63.
-http://portal.acm.org/citation.cfm?id=129906
+```
+ISC License
 
-Computer graphics and geometric modeling: implementation and algorithms
-By Max K. Agoston
-Springer; 1 edition (January 4, 2005)
-http://books.google.com/books?q=vatti+clipping+agoston
+Copyright (c) 2015, Mapbox
 
-See also:
-"Polygon Offsetting by Computing Winding Numbers"
-Paper no. DETC2005-85513 pp. 565-575
-ASME 2005 International Design Engineering Technical Conferences
-and Computers and Information in Engineering Conference (IDETC/CIE2005)
-September 24-28, 2005 , Long Beach, California, USA
-http://www.me.berkeley.edu/~mcmains/pubs/DAC05OffsetPolygon.pdf
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
 
-===========================================================================
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.
 
-MapLibre-GL-Native uses portions of BugshotKit.
+```
 
-The MIT License (MIT)
+---
 
-Copyright (c) 2014 marcoarment
+### [cheap-ruler-cpp](https://github.com/mapbox/cheap-ruler-cpp) by Mapbox
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
+```
+ISC License
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+Copyright (c) 2017, Mapbox
+
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.
+
+```
+
+---
+
+### [Boost C++ Libraries](https://www.boost.org) by Boost authors
+
+```
+Boost Software License - Version 1.0 - August 17th, 2003
+
+Permission is hereby granted, free of charge, to any person or organization
+obtaining a copy of the software and accompanying documentation covered by
+this license (the "Software") to use, reproduce, display, distribute,
+execute, and transmit the Software, and to prepare derivative works of the
+Software, and to permit third-parties to whom the Software is furnished to
+do so, all subject to the following:
+
+The copyright notices in the Software and this entire statement, including
+the above license grant, this restriction and the following disclaimer,
+must be included in all copies of the Software, in whole or in part, and
+all derivative works of the Software, unless such copies or derivative
+works are solely in the form of machine-executable object code generated by
+a source language processor.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT
+SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE
+FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
 
-===========================================================================
+```
 
-MapLibre-GL-Native uses portions of CSS Color Parser.
+---
 
+### [csscolorparser](https://github.com/mapbox/css-color-parser-cpp) by Dean McNamee and Konstantin Käfer
+
+```
 (c) Dean McNamee <dean@gmail.com>, 2012.
-C++ port by Konstantin Käfer <mail@kkaefer.com>, 2014.
-
-https://github.com/deanm/css-color-parser-js
-https://github.com/kkaefer/css-color-parser-cpp
+(c) Konstantin Käfer <mail@kkaefer.com>, 2014.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to
@@ -199,10 +229,474 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
 
+```
+
+---
+
+### [earcut.hpp](https://github.com/mapbox/earcut.hpp) by Mapbox
+
+```
+ISC License
+
+Copyright (c) 2015, Mapbox
+
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.
+
+```
+
+---
+
+### [eternal](https://github.com/mapbox/eternal) by Mapbox
+
+```
+ISC License
+
+Copyright (c) 2018, Mapbox
+
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.
+
+```
+
+---
+
+### [parsedate](https://curl.haxx.se) by Daniel Stenberg and others
+
+```
+COPYRIGHT AND PERMISSION NOTICE
+
+Copyright (c) 1996 - 2020, Daniel Stenberg, <daniel@haxx.se>, and many
+contributors, see the THANKS file.
+
+All rights reserved.
+
+Permission to use, copy, modify, and distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright
+notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF THIRD PARTY RIGHTS. IN
+NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+OR OTHER DEALINGS IN THE SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder shall not
+be used in advertising or otherwise to promote the sale, use or other dealings
+in this Software without prior written authorization of the copyright holder.
+
+```
+
+---
+
+### [polylabel](https://github.com/mapbox/polylabel) by Mapbox
+
+```
+ISC License
+Copyright (c) 2016 Mapbox
+
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND ISC DISCLAIMS ALL WARRANTIES WITH REGARD TO
+THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS.
+IN NO EVENT SHALL ISC BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
+CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA
+OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+SOFTWARE.
+
+```
+
+---
+
+### [protozero](https://github.com/mapbox/protozero) by Mapbox
+
+```
+protozero copyright (c) Mapbox.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES LOSS OF USE, DATA, OR
+PROFITS OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+```
+
+---
+
+### [unique_resource](https://github.com/okdshin/unique_resource) by Shintarou Okada
+
+```
+Boost Software License - Version 1.0 - August 17th, 2003
+
+Permission is hereby granted, free of charge, to any person or organization
+obtaining a copy of the software and accompanying documentation covered by
+this license (the "Software") to use, reproduce, display, distribute,
+execute, and transmit the Software, and to prepare derivative works of the
+Software, and to permit third-parties to whom the Software is furnished to
+do so, all subject to the following:
+
+The copyright notices in the Software and this entire statement, including
+the above license grant, this restriction and the following disclaimer,
+must be included in all copies of the Software, in whole or in part, and
+all derivative works of the Software, unless such copies or derivative
+works are solely in the form of machine-executable object code generated by
+a source language processor.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT
+SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE
+FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+```
+
+---
+
+### [vector-tile](https://github.com/mapbox/vector-tile) by Mapbox
+
+```
+Copyright (c) 2016, Mapbox
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+```
+
+---
+
+### [wagyu](https://github.com/mapbox/wagyu.git) by Angus Johnson and Mapbox
+
+```
+Parts of the code in the Wagyu Library are derived from the version of the 
+Clipper Library by Angus Johnson listed below.
+
+Author    :  Angus Johnson
+Version   :  6.4.0
+Date      :  2 July 2015
+Website   :  http://www.angusj.com
+
+Copyright for portions of the derived code in the Wagyu library are held 
+by Angus Johnson, 2010-2015. All other copyright for the Wagyu Library are held by 
+Mapbox, 2016. This code is published in accordance with, and retains the same license
+as the Clipper Library by Angus Johnson.
+
+Copyright (c) 2010-2015, Angus Johnson
+Copyright (c) 2016, Mapbox
+
+Permission is hereby granted, free of charge, to any person or organization
+obtaining a copy of the software and accompanying documentation covered by
+this license (the "Software") to use, reproduce, display, distribute,
+execute, and transmit the Software, and to prepare derivative works of the
+Software, and to permit third-parties to whom the Software is furnished to
+do so, all subject to the following:
+
+The copyright notices in the Software and this entire statement, including
+the above license grant, this restriction and the following disclaimer,
+must be included in all copies of the Software, in whole or in part, and
+all derivative works of the Software, unless such copies or derivative
+works are solely in the form of machine-executable object code generated by
+a source language processor.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT
+SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE
+FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+```
+
+---
+
+### [mapbox-base](https://github.com/mapbox/mapbox-base) by Mapbox
+
+```
+Copyright (c) MapBox
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+- Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or
+  other materials provided with the distribution.
+- Neither the name "MapBox" nor the names of its contributors may be
+  used to endorse or promote products derived from this software without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES
+LOSS OF USE, DATA, OR PROFITS OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
+
+---
+
+### [expected-lite](https://github.com/martinmoene/expected-lite) by Martin Moene
+
+```
+Boost Software License - Version 1.0 - August 17th, 2003
+
+Permission is hereby granted, free of charge, to any person or organization
+obtaining a copy of the software and accompanying documentation covered by
+this license (the "Software") to use, reproduce, display, distribute,
+execute, and transmit the Software, and to prepare derivative works of the
+Software, and to permit third-parties to whom the Software is furnished to
+do so, all subject to the following:
+
+The copyright notices in the Software and this entire statement, including
+the above license grant, this restriction and the following disclaimer,
+must be included in all copies of the Software, in whole or in part, and
+all derivative works of the Software, unless such copies or derivative
+works are solely in the form of machine-executable object code generated by
+a source language processor.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT
+SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE
+FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+```
+
+---
+
+### [RapidJSON](https://rapidjson.org) by THL A29 Limited, a Tencent company, and Milo Yip
+
+```
+Tencent is pleased to support the open source community by making RapidJSON available. 
+ 
+Copyright (C) 2015 THL A29 Limited, a Tencent company, and Milo Yip.  All rights reserved.
+
+If you have downloaded a copy of the RapidJSON binary from Tencent, please note that the RapidJSON binary is licensed under the MIT License.
+If you have downloaded a copy of the RapidJSON source code from Tencent, please note that RapidJSON source code is licensed under the MIT License, except for the third-party components listed below which are subject to different license terms.  Your integration of RapidJSON into your own projects may require compliance with the MIT License, as well as the other licenses applicable to the third-party components included within RapidJSON. To avoid the problematic JSON license in your own projects, it's sufficient to exclude the bin/jsonchecker/ directory, as it's the only code under the JSON license.
+A copy of the MIT License is included in this file.
+
+Other dependencies and licenses:
+
+Open Source Software Licensed Under the BSD License:
+--------------------------------------------------------------------
+
+The msinttypes r29 
+Copyright (c) 2006-2013 Alexander Chemeris 
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. 
+* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+* Neither the name of  copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS AND CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES LOSS OF USE, DATA, OR PROFITS OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Open Source Software Licensed Under the JSON License:
+--------------------------------------------------------------------
+
+json.org 
+Copyright (c) 2002 JSON.org
+All Rights Reserved.
+
+JSON_checker
+Copyright (c) 2002 JSON.org
+All Rights Reserved.
+
+	
+Terms of the JSON License:
+---------------------------------------------------
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+The Software shall be used for Good, not Evil.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+Terms of the MIT License:
+--------------------------------------------------------------------
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+```
+
+---
+
+### [geojson.hpp](https://github.com/mapbox/geojson-cpp) by Mapbox
+
+```
+Copyright (c) 2016, Mapbox
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+```
+
+---
+
+### [geometry.hpp](https://github.com/mapbox/geometry.hpp) by Mapbox
+
+```
+Copyright (c) 2016, Mapbox
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+```
+
+---
+
+### [Optional](https://github.com/akrzemi1/Optional) by Andrzej Krzemienski
+
+```
+Boost Software License - Version 1.0 - August 17th, 2003
+
+Permission is hereby granted, free of charge, to any person or organization
+obtaining a copy of the software and accompanying documentation covered by
+this license (the "Software") to use, reproduce, display, distribute,
+execute, and transmit the Software, and to prepare derivative works of the
+Software, and to permit third-parties to whom the Software is furnished to
+do so, all subject to the following:
+
+The copyright notices in the Software and this entire statement, including
+the above license grant, this restriction and the following disclaimer,
+must be included in all copies of the Software, in whole or in part, and
+all derivative works of the Software, unless such copies or derivative
+works are solely in the form of machine-executable object code generated by
+a source language processor.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT
+SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE
+FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+```
+
+---
+
+### [variant](https://github.com/mapbox/variant) by Mapbox
+
+```
+Copyright (c) MapBox
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+- Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or
+  other materials provided with the distribution.
+- Neither the name "MapBox" nor the names of its contributors may be
+  used to endorse or promote products derived from this software without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES
+LOSS OF USE, DATA, OR PROFITS OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
+
+---
+
 ===========================================================================
 
-MapLibre-GL-Native uses portions of GLFW.
+### MapLibre-GL-Native uses portions of GLFW.
 
+```
 Copyright (c) 2002-2006 Marcus Geelnard
 Copyright (c) 2006-2010 Camilla Berglund <elmindreda@elmindreda.org>
 
@@ -224,11 +718,13 @@ freely, subject to the following restrictions:
 
 3. This notice may not be removed or altered from any source
    distribution.
+```
 
 ===========================================================================
 
-MapLibre-GL-Native uses portions of libc++.
+### MapLibre-GL-Native uses portions of libc++.
 
+```
 The libc++ library is dual licensed under both the University of Illinois
 "BSD-Like" license and the MIT license.  As a user of this code you may choose
 to use it under either license.  As a contributor, you agree to allow your code
@@ -301,11 +797,13 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+```
 
 ===========================================================================
 
-MapLibre-GL-Native uses portions of libcurl.
+### MapLibre-GL-Native uses portions of libcurl.
 
+```
 COPYRIGHT AND PERMISSION NOTICE
 
 Copyright (c) 1996 - 2015, Daniel Stenberg, <daniel@haxx.se>.
@@ -327,11 +825,13 @@ OR OTHER DEALINGS IN THE SOFTWARE.
 Except as contained in this notice, the name of a copyright holder shall not
 be used in advertising or otherwise to promote the sale, use or other dealings
 in this Software without prior written authorization of the copyright holder.
+```
 
 ===========================================================================
 
-MapLibre-GL-Native uses portions of libjpeg-turbo.
+### MapLibre-GL-Native uses portions of libjpeg-turbo.
 
+```
 This software is based in part on the work of the Independent JPEG Group.
 
 Copyright (C)2009-2015 D. R. Commander.  All Rights Reserved.
@@ -361,11 +861,13 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 
 TurboJPEG/LJT: this implements the TurboJPEG API using libjpeg or libjpeg-turbo
+```
 
 ===========================================================================
 
-MapLibre-GL-Native uses portions of libpng.
+### MapLibre-GL-Native uses portions of libpng.
 
+```
 This copy of the libpng notices is provided for your convenience.  In case of
 any discrepancy between this copy and the notices in the file png.h that is
 included in the libpng distribution, the latter shall prevail.
@@ -456,11 +958,13 @@ fee, and encourage the use of this source code as a component to
 supporting the PNG file format in commercial products.  If you use this
 source code in a product, acknowledgment is not required but would be
 appreciated.
+```
 
 ===========================================================================
 
-MapLibre-GL-Native uses portions of libuv.
+### MapLibre-GL-Native uses portions of libuv.
 
+```
 libuv is part of the Node project: http://nodejs.org/
 libuv may be distributed alone under Node's license:
 
@@ -507,11 +1011,13 @@ The externally maintained libraries used by libuv are:
 - android-ifaddrs.h, android-ifaddrs.c, copyright Berkeley Software Design
   Inc, Kenneth MacKay and Emergya (Cloud4all, FP7/2007-2013, grant agreement
   n° 289016). Three clause BSD license.
+```
 
 ===========================================================================
 
-MapLibre-GL-Native uses portions of libzip.
+### MapLibre-GL-Native uses portions of libzip.
 
+```
 Copyright (C) 1999-2014 Dieter Baron and Thomas Klausner
 
 The authors can be contacted at <libzip@nih.at>
@@ -543,11 +1049,13 @@ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
 IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
 OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
 
 ===========================================================================
 
-MapLibre-GL-Native uses portions of LOST.
+### MapLibre-GL-Native uses portions of LOST.
 
+```
 Copyright (c) 2014 Mapzen
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -561,12 +1069,13 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+```
 
 ===========================================================================
 
-MapLibre-GL-Native uses portions of the Mapbox iOS SDK, which was derived from the
-Route-Me open source project, including the Alpstein fork of it.
+### MapLibre-GL-Native uses portions of the Mapbox iOS SDK, which was derived from the Route-Me open source project, including the Alpstein fork of it.
 
+```
 The Route-Me license appears below.
 
 Copyright (c) 2008-2013, Route-Me Contributors
@@ -592,11 +1101,13 @@ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
 CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
+```
 
 ===========================================================================
 
-MapLibre-GL-Native uses portions of nunicode.
+### MapLibre-GL-Native uses portions of nunicode.
 
+```
 Copyright (c) 2013 Aleksey Tulinov <aleksey.tulinov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -616,11 +1127,13 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+```
 
 ===========================================================================
 
-MapLibre-GL-Native uses portions of OkHTTP.
+### MapLibre-GL-Native uses portions of OkHTTP.
 
+```
 Copyright 2014 Square, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -634,11 +1147,13 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+```
 
 ===========================================================================
 
-MapLibre-GL-Native uses portions of OpenSSL.
+### MapLibre-GL-Native uses portions of OpenSSL.
 
+```
 LICENSE ISSUES
 ==============
 
@@ -759,113 +1274,7 @@ The licence and distribution terms for any publically available version or
 derivative of this code cannot be changed.  i.e. this code cannot simply be
 copied and put under another distribution licence
 [including the GNU Public Licence.]
-
-===========================================================================
-
-MapLibre-GL-Native uses portions of RapidJSON.
-
-Tencent is pleased to support the open source community by making RapidJSON
-available.
-
-Copyright (C) 2015 THL A29 Limited, a Tencent company, and Milo Yip.  All rights
-reserved.
-
-If you have downloaded a copy of the RapidJSON binary from Tencent, please note
-that the RapidJSON binary is licensed under the MIT License. If you have
-downloaded a copy of the RapidJSON source code from Tencent, please note that
-RapidJSON source code is licensed under the MIT License, except for the third-
-party components listed below which are subject to different license terms.
-Your integration of RapidJSON into your own projects may require compliance with
-the MIT License, as well as the other licenses applicable to the third-party
-components included within RapidJSON. To avoid the problematic JSON license in
-your own projects, it's sufficient to exclude the bin/jsonchecker/ directory, as
-it's the only code under the JSON license. A copy of the MIT License is included
-in this file.
-
-Other dependencies and licenses:
-
-Open Source Software Licensed Under the BSD License:
---------------------------------------------------------------------
-
-The msinttypes r29
-Copyright (c) 2006-2013 Alexander Chemeris
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-* Redistributions of source code must retain the above copyright notice,
-  this list of conditions and the following disclaimer.
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
-* Neither the name of copyright holder nor the names of its contributors may be
-  used to endorse or promote products derived from this software without
-  specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND ANY
-EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE REGENTS AND CONTRIBUTORS BE LIABLE FOR ANY
-DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-Open Source Software Licensed Under the JSON License:
---------------------------------------------------------------------
-
-json.org
-Copyright (c) 2002 JSON.org
-All Rights Reserved.
-
-JSON_checker
-Copyright (c) 2002 JSON.org
-All Rights Reserved.
-
-Terms of the JSON License:
----------------------------------------------------
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-The Software shall be used for Good, not Evil.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-Terms of the MIT License:
---------------------------------------------------------------------
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+```
 
 ===========================================================================
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -83,7 +83,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ```
 
----
+===========================================================================
 
 ### MapLibre-GL-Native uses portions of [supercluster.hpp](https://github.com/mapbox/supercluster.hpp) by Mapbox
 
@@ -104,7 +104,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ```
 
----
+===========================================================================
 
 ### MapLibre-GL-Native uses portions of [shelf-pack-cpp](https://github.com/mapbox/shelf-pack-cpp) by Mapbox
 
@@ -127,7 +127,7 @@ THIS SOFTWARE.
 
 ```
 
----
+===========================================================================
 
 ### MapLibre-GL-Native uses portions of [geojson-vt-cpp](https://github.com/mapbox/geojson-vt-cpp) by Mapbox
 
@@ -150,7 +150,7 @@ THIS SOFTWARE.
 
 ```
 
----
+===========================================================================
 
 ### MapLibre-GL-Native uses portions of [cheap-ruler-cpp](https://github.com/mapbox/cheap-ruler-cpp) by Mapbox
 
@@ -173,7 +173,7 @@ THIS SOFTWARE.
 
 ```
 
----
+===========================================================================
 
 ### MapLibre-GL-Native uses portions of [Boost C++ Libraries](https://www.boost.org) by Boost authors
 
@@ -204,7 +204,7 @@ DEALINGS IN THE SOFTWARE.
 
 ```
 
----
+===========================================================================
 
 ### MapLibre-GL-Native uses portions of [csscolorparser](https://github.com/mapbox/css-color-parser-cpp) by Dean McNamee and Konstantin Käfer
 
@@ -232,7 +232,7 @@ IN THE SOFTWARE.
 
 ```
 
----
+===========================================================================
 
 ### MapLibre-GL-Native uses portions of [earcut.hpp](https://github.com/mapbox/earcut.hpp) by Mapbox
 
@@ -255,7 +255,7 @@ THIS SOFTWARE.
 
 ```
 
----
+===========================================================================
 
 ### MapLibre-GL-Native uses portions of [eternal](https://github.com/mapbox/eternal) by Mapbox
 
@@ -278,7 +278,7 @@ THIS SOFTWARE.
 
 ```
 
----
+===========================================================================
 
 ### MapLibre-GL-Native uses portions of [parsedate](https://curl.haxx.se) by Daniel Stenberg and others
 
@@ -308,7 +308,7 @@ in this Software without prior written authorization of the copyright holder.
 
 ```
 
----
+===========================================================================
 
 ### MapLibre-GL-Native uses portions of [polylabel](https://github.com/mapbox/polylabel) by Mapbox
 
@@ -330,7 +330,7 @@ SOFTWARE.
 
 ```
 
----
+===========================================================================
 
 ### MapLibre-GL-Native uses portions of [protozero](https://github.com/mapbox/protozero) by Mapbox
 
@@ -362,7 +362,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ```
 
----
+===========================================================================
 
 ### MapLibre-GL-Native uses portions of [unique_resource](https://github.com/okdshin/unique_resource) by Shintarou Okada
 
@@ -393,7 +393,7 @@ DEALINGS IN THE SOFTWARE.
 
 ```
 
----
+===========================================================================
 
 ### MapLibre-GL-Native uses portions of [vector-tile](https://github.com/mapbox/vector-tile) by Mapbox
 
@@ -414,7 +414,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ```
 
----
+===========================================================================
 
 ### MapLibre-GL-Native uses portions of [wagyu](https://github.com/mapbox/wagyu.git) by Angus Johnson and Mapbox
 
@@ -459,7 +459,7 @@ DEALINGS IN THE SOFTWARE.
 
 ```
 
----
+===========================================================================
 
 ### MapLibre-GL-Native uses portions of [mapbox-base](https://github.com/mapbox/mapbox-base) by Mapbox
 
@@ -491,7 +491,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
 
----
+===========================================================================
 
 ### MapLibre-GL-Native uses portions of [expected-lite](https://github.com/martinmoene/expected-lite) by Martin Moene
 
@@ -522,7 +522,7 @@ DEALINGS IN THE SOFTWARE.
 
 ```
 
----
+===========================================================================
 
 ### MapLibre-GL-Native uses portions of [RapidJSON](https://rapidjson.org) by THL A29 Limited, a Tencent company, and Milo Yip
 
@@ -538,7 +538,7 @@ A copy of the MIT License is included in this file.
 Other dependencies and licenses:
 
 Open Source Software Licensed Under the BSD License:
---------------------------------------------------------------------
+==================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================--
 
 The msinttypes r29 
 Copyright (c) 2006-2013 Alexander Chemeris 
@@ -553,7 +553,7 @@ Redistribution and use in source and binary forms, with or without modification,
 THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS AND CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES LOSS OF USE, DATA, OR PROFITS OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 Open Source Software Licensed Under the JSON License:
---------------------------------------------------------------------
+==================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================--
 
 json.org 
 Copyright (c) 2002 JSON.org
@@ -565,7 +565,7 @@ All Rights Reserved.
 
 	
 Terms of the JSON License:
----------------------------------------------------
+===========================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
@@ -577,7 +577,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 
 Terms of the MIT License:
---------------------------------------------------------------------
+==================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================--
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
@@ -587,7 +587,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ```
 
----
+===========================================================================
 
 ### MapLibre-GL-Native uses portions of [geojson.hpp](https://github.com/mapbox/geojson-cpp) by Mapbox
 
@@ -608,7 +608,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ```
 
----
+===========================================================================
 
 ### MapLibre-GL-Native uses portions of [geometry.hpp](https://github.com/mapbox/geometry.hpp) by Mapbox
 
@@ -628,7 +628,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 ```
 
----
+===========================================================================
 
 ### MapLibre-GL-Native uses portions of [Optional](https://github.com/akrzemi1/Optional) by Andrzej Krzemienski
 
@@ -659,7 +659,7 @@ DEALINGS IN THE SOFTWARE.
 
 ```
 
----
+===========================================================================
 
 ### MapLibre-GL-Native uses portions of [variant](https://github.com/mapbox/variant) by Mapbox
 
@@ -691,7 +691,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
 
----
+===========================================================================
 
 ### MapLibre-GL-Native uses portions of GLFW.
 
@@ -719,7 +719,7 @@ freely, subject to the following restrictions:
    distribution.
 ```
 
----
+===========================================================================
 
 ### MapLibre-GL-Native uses portions of libc++.
 
@@ -798,7 +798,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ```
 
----
+===========================================================================
 
 ### MapLibre-GL-Native uses portions of libcurl.
 
@@ -862,7 +862,7 @@ POSSIBILITY OF SUCH DAMAGE.
 TurboJPEG/LJT: this implements the TurboJPEG API using libjpeg or libjpeg-turbo
 ```
 
----
+===========================================================================
 
 ### MapLibre-GL-Native uses portions of libpng.
 
@@ -959,7 +959,7 @@ source code in a product, acknowledgment is not required but would be
 appreciated.
 ```
 
----
+===========================================================================
 
 ### MapLibre-GL-Native uses portions of libuv.
 
@@ -1012,7 +1012,7 @@ The externally maintained libraries used by libuv are:
   n° 289016). Three clause BSD license.
 ```
 
----
+===========================================================================
 
 ### MapLibre-GL-Native uses portions of libzip.
 
@@ -1050,7 +1050,7 @@ OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
 
----
+===========================================================================
 
 ### MapLibre-GL-Native uses portions of LOST.
 
@@ -1102,7 +1102,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 ```
 
----
+===========================================================================
 
 ### MapLibre-GL-Native uses portions of nunicode.
 
@@ -1128,7 +1128,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ```
 
----
+===========================================================================
 
 ### MapLibre-GL-Native uses portions of OkHTTP.
 
@@ -1148,7 +1148,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ```
 
----
+===========================================================================
 
 ### MapLibre-GL-Native uses portions of OpenSSL.
 
@@ -1163,7 +1163,7 @@ Open Source licenses. In case of any license issues related to OpenSSL
 please contact openssl-core@openssl.org.
 
 OpenSSL License
----------------
+=======================================================================================================================================================================================================================================================================================================================================================================================
 
 Copyright (c) 1998-2011 The OpenSSL Project.  All rights reserved.
 
@@ -1216,7 +1216,7 @@ This product includes cryptographic software written by Eric Young
 Hudson (tjh@cryptsoft.com).
 
 Original SSLeay License
------------------------
+=============================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================--
 
 Copyright (C) 1995-1998 Eric Young (eay@cryptsoft.com)
 All rights reserved.
@@ -1275,7 +1275,7 @@ copied and put under another distribution licence
 [including the GNU Public Licence.]
 ```
 
----
+===========================================================================
 
 ### MapLibre-GL-Native uses portions of Reachability.
 ```
@@ -1304,7 +1304,7 @@ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 
----
+===========================================================================
 
 MapLibre-GL-Native uses portions of SQLite.
 
@@ -1319,7 +1319,7 @@ a legal notice, here is a blessing:
 
 ```
 
----
+===========================================================================
 
 ### MapLibre-GL-Native uses portions of SVPulsingAnnotationView.
 
@@ -1341,7 +1341,7 @@ THIS SOFTWARE.
 
 ```
 
----
+===========================================================================
 
 ### MapLibre-GL-Native uses portions of zlib.
 
@@ -1378,7 +1378,7 @@ freely, subject to the following restrictions:
   jloup@gzip.org          madler@alumni.caltech.edu
 ```
 
----
+===========================================================================
 
 MapLibre-GL-Native uses portions of Realm Objective-C.
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1380,7 +1380,7 @@ freely, subject to the following restrictions:
 
 ===========================================================================
 
-MapLibre-GL-Native uses portions of Realm Objective-C.
+### MapLibre-GL-Native uses portions of Realm Objective-C.
 
 ```
 Copyright 2015 Realm Inc.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -693,8 +693,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ---
 
-===========================================================================
-
 ### MapLibre-GL-Native uses portions of GLFW.
 
 ```
@@ -721,7 +719,7 @@ freely, subject to the following restrictions:
    distribution.
 ```
 
-===========================================================================
+---
 
 ### MapLibre-GL-Native uses portions of libc++.
 
@@ -800,7 +798,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ```
 
-===========================================================================
+---
 
 ### MapLibre-GL-Native uses portions of libcurl.
 
@@ -864,7 +862,7 @@ POSSIBILITY OF SUCH DAMAGE.
 TurboJPEG/LJT: this implements the TurboJPEG API using libjpeg or libjpeg-turbo
 ```
 
-===========================================================================
+---
 
 ### MapLibre-GL-Native uses portions of libpng.
 
@@ -961,7 +959,7 @@ source code in a product, acknowledgment is not required but would be
 appreciated.
 ```
 
-===========================================================================
+---
 
 ### MapLibre-GL-Native uses portions of libuv.
 
@@ -1014,7 +1012,7 @@ The externally maintained libraries used by libuv are:
   n° 289016). Three clause BSD license.
 ```
 
-===========================================================================
+---
 
 ### MapLibre-GL-Native uses portions of libzip.
 
@@ -1052,7 +1050,7 @@ OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
 
-===========================================================================
+---
 
 ### MapLibre-GL-Native uses portions of LOST.
 
@@ -1104,7 +1102,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 ```
 
-===========================================================================
+---
 
 ### MapLibre-GL-Native uses portions of nunicode.
 
@@ -1130,7 +1128,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ```
 
-===========================================================================
+---
 
 ### MapLibre-GL-Native uses portions of OkHTTP.
 
@@ -1150,7 +1148,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ```
 
-===========================================================================
+---
 
 ### MapLibre-GL-Native uses portions of OpenSSL.
 
@@ -1277,10 +1275,10 @@ copied and put under another distribution licence
 [including the GNU Public Licence.]
 ```
 
-===========================================================================
+---
 
-MapLibre-GL-Native uses portions of Reachability.
-
+### MapLibre-GL-Native uses portions of Reachability.
+```
 Copyright (c) 2011, Tony Million.
 All rights reserved.
 
@@ -1306,7 +1304,7 @@ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 
-===========================================================================
+---
 
 MapLibre-GL-Native uses portions of SQLite.
 
@@ -1319,9 +1317,13 @@ a legal notice, here is a blessing:
     May you find forgiveness for yourself and forgive others.
     May you share freely, never taking more than you give.
 
-===========================================================================
+```
 
-MapLibre-GL-Native uses portions of SVPulsingAnnotationView.
+---
+
+### MapLibre-GL-Native uses portions of SVPulsingAnnotationView.
+
+```
 
 Copyright (c) 2013, Sam Vermette <hello@samvermette.com>
 
@@ -1337,9 +1339,13 @@ OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
 TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
-===========================================================================
+```
 
-MapLibre-GL-Native uses portions of zlib.
+---
+
+### MapLibre-GL-Native uses portions of zlib.
+
+```
 
 Acknowledgments:
 
@@ -1370,11 +1376,13 @@ freely, subject to the following restrictions:
 
   Jean-loup Gailly        Mark Adler
   jloup@gzip.org          madler@alumni.caltech.edu
+```
 
-===========================================================================
+---
 
 MapLibre-GL-Native uses portions of Realm Objective-C.
 
+```
 Copyright 2015 Realm Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -1388,11 +1396,12 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-
+```
 ===========================================================================
 
-Leaflet - BSD 2-Clause License
-
+### [Leaflet](https://github.com/Leaflet/Leaflet)
+```
+BSD 2-Clause License
 Copyright (c) 2010-2023, Volodymyr Agafonkin
 Copyright (c) 2010-2011, CloudMade
 All rights reserved.
@@ -1417,3 +1426,4 @@ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -29,7 +29,7 @@ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
-===========================================================================
+---
 
 ### [MapLibre-GL-Native](https://github.com/maplibre/maplibre-gl-native)
 ```
@@ -62,7 +62,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
 
-===========================================================================
+---
 
 ### MapLibre-GL-Native uses portions of [kdbush.hpp](https://github.com/mourner/kdbush.hpp) by Vladimir Agafonkin
 
@@ -826,7 +826,7 @@ be used in advertising or otherwise to promote the sale, use or other dealings
 in this Software without prior written authorization of the copyright holder.
 ```
 
-===========================================================================
+---
 
 ### MapLibre-GL-Native uses portions of libjpeg-turbo.
 
@@ -1070,7 +1070,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ```
 
-===========================================================================
+---
 
 ### MapLibre-GL-Native uses portions of the Mapbox iOS SDK, which was derived from the Route-Me open source project, including the Alpstein fork of it.
 
@@ -1397,7 +1397,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ```
-===========================================================================
+---
 
 ### [Leaflet](https://github.com/Leaflet/Leaflet)
 ```

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,6 @@
 ## [TileServer GL](https://github.com/maptiler/tileserver-gl)
 ```
+BSD 2-Clause License
 Copyright (c) 2023, MapTiler.com
 Copyright (c) 2016, Klokan Technologies GmbH
 
@@ -41,12 +42,12 @@ Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
 met:
 
-* Redistributions of source code must retain the above copyright
-  notice, this list of conditions and the following disclaimer.
-* Redistributions in binary form must reproduce the above copyright
-  notice, this list of conditions and the following disclaimer in
-  the documentation and/or other materials provided with the
-  distribution.
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the
+   distribution.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -30,7 +30,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ===========================================================================
 
-mapbox-gl-native copyright (c) 2014-2016 Mapbox.
+MapLibre-GL-Native - BSD 2-Clause License
+
+Copyright (c) 2021 MapLibre contributors
+Copyright (c) 2018-2021 MapTiler.com
+Copyright (c) 2014-2020 Mapbox
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -57,7 +61,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ===========================================================================
 
-Mapbox GL uses portions of Android Gesture Detectors Framework.
+MapLibre-GL-Native uses portions of Android Gesture Detectors Framework.
 
 Copyright (c) 2012, Almer Thie
 
@@ -85,7 +89,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ===========================================================================
 
-Mapbox GL uses portions of Android Support Library.
+MapLibre-GL-Native uses portions of Android Support Library.
 
 Copyright (c) 2005-2013, The Android Open Source Project
 
@@ -103,7 +107,7 @@ limitations under the License.
 
 ===========================================================================
 
-Mapbox GL uses portions of Boost.
+MapLibre-GL-Native uses portions of Boost.
 
 Distributed under the Boost Software License, Version 1.0.
 
@@ -111,7 +115,7 @@ http://www.boost.org/LICENSE_1_0.txt
 
 ===========================================================================
 
-Mapbox GL uses portions of Clipper.
+MapLibre-GL-Native uses portions of Clipper.
 
 Author    :  Angus Johnson
 Version   :  6.1.3a
@@ -144,7 +148,7 @@ http://www.me.berkeley.edu/~mcmains/pubs/DAC05OffsetPolygon.pdf
 
 ===========================================================================
 
-Mapbox GL uses portions of BugshotKit.
+MapLibre-GL-Native uses portions of BugshotKit.
 
 The MIT License (MIT)
 
@@ -169,7 +173,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ===========================================================================
 
-Mapbox GL uses portions of CSS Color Parser.
+MapLibre-GL-Native uses portions of CSS Color Parser.
 
 (c) Dean McNamee <dean@gmail.com>, 2012.
 C++ port by Konstantin Käfer <mail@kkaefer.com>, 2014.
@@ -197,7 +201,7 @@ IN THE SOFTWARE.
 
 ===========================================================================
 
-Mapbox GL uses portions of GLFW.
+MapLibre-GL-Native uses portions of GLFW.
 
 Copyright (c) 2002-2006 Marcus Geelnard
 Copyright (c) 2006-2010 Camilla Berglund <elmindreda@elmindreda.org>
@@ -223,7 +227,7 @@ freely, subject to the following restrictions:
 
 ===========================================================================
 
-Mapbox GL uses portions of libc++.
+MapLibre-GL-Native uses portions of libc++.
 
 The libc++ library is dual licensed under both the University of Illinois
 "BSD-Like" license and the MIT license.  As a user of this code you may choose
@@ -300,7 +304,7 @@ THE SOFTWARE.
 
 ===========================================================================
 
-Mapbox GL uses portions of libcurl.
+MapLibre-GL-Native uses portions of libcurl.
 
 COPYRIGHT AND PERMISSION NOTICE
 
@@ -326,7 +330,7 @@ in this Software without prior written authorization of the copyright holder.
 
 ===========================================================================
 
-Mapbox GL uses portions of libjpeg-turbo.
+MapLibre-GL-Native uses portions of libjpeg-turbo.
 
 This software is based in part on the work of the Independent JPEG Group.
 
@@ -360,7 +364,7 @@ TurboJPEG/LJT: this implements the TurboJPEG API using libjpeg or libjpeg-turbo
 
 ===========================================================================
 
-Mapbox GL uses portions of libpng.
+MapLibre-GL-Native uses portions of libpng.
 
 This copy of the libpng notices is provided for your convenience.  In case of
 any discrepancy between this copy and the notices in the file png.h that is
@@ -455,7 +459,7 @@ appreciated.
 
 ===========================================================================
 
-Mapbox GL uses portions of libuv.
+MapLibre-GL-Native uses portions of libuv.
 
 libuv is part of the Node project: http://nodejs.org/
 libuv may be distributed alone under Node's license:
@@ -506,7 +510,7 @@ The externally maintained libraries used by libuv are:
 
 ===========================================================================
 
-Mapbox GL uses portions of libzip.
+MapLibre-GL-Native uses portions of libzip.
 
 Copyright (C) 1999-2014 Dieter Baron and Thomas Klausner
 
@@ -542,7 +546,7 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ===========================================================================
 
-Mapbox GL uses portions of LOST.
+MapLibre-GL-Native uses portions of LOST.
 
 Copyright (c) 2014 Mapzen
 
@@ -560,7 +564,7 @@ limitations under the License.
 
 ===========================================================================
 
-Mapbox GL uses portions of the Mapbox iOS SDK, which was derived from the
+MapLibre-GL-Native uses portions of the Mapbox iOS SDK, which was derived from the
 Route-Me open source project, including the Alpstein fork of it.
 
 The Route-Me license appears below.
@@ -591,7 +595,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 ===========================================================================
 
-Mapbox GL uses portions of nunicode.
+MapLibre-GL-Native uses portions of nunicode.
 
 Copyright (c) 2013 Aleksey Tulinov <aleksey.tulinov@gmail.com>
 
@@ -615,7 +619,7 @@ THE SOFTWARE.
 
 ===========================================================================
 
-Mapbox GL uses portions of OkHTTP.
+MapLibre-GL-Native uses portions of OkHTTP.
 
 Copyright 2014 Square, Inc.
 
@@ -633,7 +637,7 @@ limitations under the License.
 
 ===========================================================================
 
-Mapbox GL uses portions of OpenSSL.
+MapLibre-GL-Native uses portions of OpenSSL.
 
 LICENSE ISSUES
 ==============
@@ -758,7 +762,7 @@ copied and put under another distribution licence
 
 ===========================================================================
 
-Mapbox GL uses portions of RapidJSON.
+MapLibre-GL-Native uses portions of RapidJSON.
 
 Tencent is pleased to support the open source community by making RapidJSON
 available.
@@ -865,7 +869,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ===========================================================================
 
-Mapbox GL uses portions of Reachability.
+MapLibre-GL-Native uses portions of Reachability.
 
 Copyright (c) 2011, Tony Million.
 All rights reserved.
@@ -894,7 +898,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 ===========================================================================
 
-Mapbox GL uses portions of SQLite.
+MapLibre-GL-Native uses portions of SQLite.
 
 2001 September 15
 
@@ -907,7 +911,7 @@ a legal notice, here is a blessing:
 
 ===========================================================================
 
-Mapbox GL uses portions of SVPulsingAnnotationView.
+MapLibre-GL-Native uses portions of SVPulsingAnnotationView.
 
 Copyright (c) 2013, Sam Vermette <hello@samvermette.com>
 
@@ -925,7 +929,7 @@ THIS SOFTWARE.
 
 ===========================================================================
 
-Mapbox GL uses portions of zlib.
+MapLibre-GL-Native uses portions of zlib.
 
 Acknowledgments:
 
@@ -959,7 +963,7 @@ freely, subject to the following restrictions:
 
 ===========================================================================
 
-Mapbox GL uses portions of Realm Objective-C.
+MapLibre-GL-Native uses portions of Realm Objective-C.
 
 Copyright 2015 Realm Inc.
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -63,7 +63,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ===========================================================================
 
-### [kdbush.hpp](https://github.com/mourner/kdbush.hpp) by Vladimir Agafonkin
+### MapLibre-GL-Native uses portions of [kdbush.hpp](https://github.com/mourner/kdbush.hpp) by Vladimir Agafonkin
 
 ```
 Copyright (c) 2016, Vladimir Agafonkin
@@ -84,7 +84,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ---
 
-### [supercluster.hpp](https://github.com/mapbox/supercluster.hpp) by Mapbox
+### MapLibre-GL-Native uses portions of [supercluster.hpp](https://github.com/mapbox/supercluster.hpp) by Mapbox
 
 ```
 Copyright (c) 2016, Mapbox
@@ -105,7 +105,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ---
 
-### [shelf-pack-cpp](https://github.com/mapbox/shelf-pack-cpp) by Mapbox
+### MapLibre-GL-Native uses portions of [shelf-pack-cpp](https://github.com/mapbox/shelf-pack-cpp) by Mapbox
 
 ```
 ISC License
@@ -128,7 +128,7 @@ THIS SOFTWARE.
 
 ---
 
-### [geojson-vt-cpp](https://github.com/mapbox/geojson-vt-cpp) by Mapbox
+### MapLibre-GL-Native uses portions of [geojson-vt-cpp](https://github.com/mapbox/geojson-vt-cpp) by Mapbox
 
 ```
 ISC License
@@ -151,7 +151,7 @@ THIS SOFTWARE.
 
 ---
 
-### [cheap-ruler-cpp](https://github.com/mapbox/cheap-ruler-cpp) by Mapbox
+### MapLibre-GL-Native uses portions of [cheap-ruler-cpp](https://github.com/mapbox/cheap-ruler-cpp) by Mapbox
 
 ```
 ISC License
@@ -174,7 +174,7 @@ THIS SOFTWARE.
 
 ---
 
-### [Boost C++ Libraries](https://www.boost.org) by Boost authors
+### MapLibre-GL-Native uses portions of [Boost C++ Libraries](https://www.boost.org) by Boost authors
 
 ```
 Boost Software License - Version 1.0 - August 17th, 2003
@@ -205,7 +205,7 @@ DEALINGS IN THE SOFTWARE.
 
 ---
 
-### [csscolorparser](https://github.com/mapbox/css-color-parser-cpp) by Dean McNamee and Konstantin Käfer
+### MapLibre-GL-Native uses portions of [csscolorparser](https://github.com/mapbox/css-color-parser-cpp) by Dean McNamee and Konstantin Käfer
 
 ```
 (c) Dean McNamee <dean@gmail.com>, 2012.
@@ -233,7 +233,7 @@ IN THE SOFTWARE.
 
 ---
 
-### [earcut.hpp](https://github.com/mapbox/earcut.hpp) by Mapbox
+### MapLibre-GL-Native uses portions of [earcut.hpp](https://github.com/mapbox/earcut.hpp) by Mapbox
 
 ```
 ISC License
@@ -256,7 +256,7 @@ THIS SOFTWARE.
 
 ---
 
-### [eternal](https://github.com/mapbox/eternal) by Mapbox
+### MapLibre-GL-Native uses portions of [eternal](https://github.com/mapbox/eternal) by Mapbox
 
 ```
 ISC License
@@ -279,7 +279,7 @@ THIS SOFTWARE.
 
 ---
 
-### [parsedate](https://curl.haxx.se) by Daniel Stenberg and others
+### MapLibre-GL-Native uses portions of [parsedate](https://curl.haxx.se) by Daniel Stenberg and others
 
 ```
 COPYRIGHT AND PERMISSION NOTICE
@@ -309,7 +309,7 @@ in this Software without prior written authorization of the copyright holder.
 
 ---
 
-### [polylabel](https://github.com/mapbox/polylabel) by Mapbox
+### MapLibre-GL-Native uses portions of [polylabel](https://github.com/mapbox/polylabel) by Mapbox
 
 ```
 ISC License
@@ -331,7 +331,7 @@ SOFTWARE.
 
 ---
 
-### [protozero](https://github.com/mapbox/protozero) by Mapbox
+### MapLibre-GL-Native uses portions of [protozero](https://github.com/mapbox/protozero) by Mapbox
 
 ```
 protozero copyright (c) Mapbox.
@@ -363,7 +363,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ---
 
-### [unique_resource](https://github.com/okdshin/unique_resource) by Shintarou Okada
+### MapLibre-GL-Native uses portions of [unique_resource](https://github.com/okdshin/unique_resource) by Shintarou Okada
 
 ```
 Boost Software License - Version 1.0 - August 17th, 2003
@@ -394,7 +394,7 @@ DEALINGS IN THE SOFTWARE.
 
 ---
 
-### [vector-tile](https://github.com/mapbox/vector-tile) by Mapbox
+### MapLibre-GL-Native uses portions of [vector-tile](https://github.com/mapbox/vector-tile) by Mapbox
 
 ```
 Copyright (c) 2016, Mapbox
@@ -415,7 +415,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ---
 
-### [wagyu](https://github.com/mapbox/wagyu.git) by Angus Johnson and Mapbox
+### MapLibre-GL-Native uses portions of [wagyu](https://github.com/mapbox/wagyu.git) by Angus Johnson and Mapbox
 
 ```
 Parts of the code in the Wagyu Library are derived from the version of the 
@@ -460,7 +460,7 @@ DEALINGS IN THE SOFTWARE.
 
 ---
 
-### [mapbox-base](https://github.com/mapbox/mapbox-base) by Mapbox
+### MapLibre-GL-Native uses portions of [mapbox-base](https://github.com/mapbox/mapbox-base) by Mapbox
 
 ```
 Copyright (c) MapBox
@@ -492,7 +492,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ---
 
-### [expected-lite](https://github.com/martinmoene/expected-lite) by Martin Moene
+### MapLibre-GL-Native uses portions of [expected-lite](https://github.com/martinmoene/expected-lite) by Martin Moene
 
 ```
 Boost Software License - Version 1.0 - August 17th, 2003
@@ -523,7 +523,7 @@ DEALINGS IN THE SOFTWARE.
 
 ---
 
-### [RapidJSON](https://rapidjson.org) by THL A29 Limited, a Tencent company, and Milo Yip
+### MapLibre-GL-Native uses portions of [RapidJSON](https://rapidjson.org) by THL A29 Limited, a Tencent company, and Milo Yip
 
 ```
 Tencent is pleased to support the open source community by making RapidJSON available. 
@@ -588,7 +588,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ---
 
-### [geojson.hpp](https://github.com/mapbox/geojson-cpp) by Mapbox
+### MapLibre-GL-Native uses portions of [geojson.hpp](https://github.com/mapbox/geojson-cpp) by Mapbox
 
 ```
 Copyright (c) 2016, Mapbox
@@ -609,7 +609,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ---
 
-### [geometry.hpp](https://github.com/mapbox/geometry.hpp) by Mapbox
+### MapLibre-GL-Native uses portions of [geometry.hpp](https://github.com/mapbox/geometry.hpp) by Mapbox
 
 ```
 Copyright (c) 2016, Mapbox
@@ -629,7 +629,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ---
 
-### [Optional](https://github.com/akrzemi1/Optional) by Andrzej Krzemienski
+### MapLibre-GL-Native uses portions of [Optional](https://github.com/akrzemi1/Optional) by Andrzej Krzemienski
 
 ```
 Boost Software License - Version 1.0 - August 17th, 2003
@@ -660,7 +660,7 @@ DEALINGS IN THE SOFTWARE.
 
 ---
 
-### [variant](https://github.com/mapbox/variant) by Mapbox
+### MapLibre-GL-Native uses portions of [variant](https://github.com/mapbox/variant) by Mapbox
 
 ```
 Copyright (c) MapBox

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 TileServer GL
 =============
-
+Copyright (c) 2023, MapTiler.com
 Copyright (c) 2016, Klokan Technologies GmbH
 
 All rights reserved.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,7 +44,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'TileServer GL'
-copyright = u'2022, MapTiler.com'
+copyright = u'2023, MapTiler.com'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
These change can be viewed easier here https://github.com/WifiDB/tileserver-gl/blob/license_update/LICENSE.md

I update the license file to reflect the use of 'maplibre-gl-native' instead of 'mapbox-gl-native'. I went though the following urls and pulled over any relevent license info.
https://github.com/maplibre/maplibre-gl-native/blob/main/LICENSE.md
https://github.com/maplibre/maplibre-gl-native/blob/main/LICENSE.mbgl-core.md

There were things the original tileserver-gl license mentioned that did not exist in the maplibre license, but I know we still use (GLFW, libc++,libcurl, libjpeg-turbo,libpng,libuv,libzip). I left these in..

There are a few things i think could be remvoed, but I'm not sure about (LOST,Mapbox iOS SDK). I left these in for now.

I reformatted these to make the license seperation more clean. in some cased, like the OpenSSL license, it was hard to tell wehere it started and ended.