### PR TITLE
Simplify signal handling

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,35 +1,9 @@
 #!/bin/sh
-
-set -e
-
-handle() {
-	SIGNAL=$(( $? - 128 ))
-	echo "Caught signal ${SIGNAL}, stopping gracefully"
-	kill -s ${SIGNAL} $(pidof node) 2>/dev/null
-}
-
-trap handle INT TERM
-
-refresh() {
-	SIGNAL=$(( $? - 128 ))
-	echo "Caught signal ${SIGNAL}, refreshing"
-	kill -s ${SIGNAL} $(pidof node) 2>/dev/null
-}
-
-trap refresh HUP
-
 if ! which -- "${1}"; then
   # first arg is not an executable
-  xvfb-run -a --server-args="-screen 0 1024x768x24" -- node /usr/src/app/ "$@" &
-	# Wait exits immediately on signals which have traps set. Store return value and wait
-	# again for all jobs to actually complete before continuing.
-	wait $! || RETVAL=$?
-	while [ ${RETVAL} = 129 ] ; do
-	  # Refressh signal HUP received. Continue waiting for signals.
-	  wait $! || RETVAL=$?
-	done
-	wait
-	exit ${RETVAL}
+  export DISPLAY=:99
+  Xvfb "${DISPLAY}" -nolisten unix &
+  exec node /usr/src/app/ -p 80 "$@"
 fi
 
 exec "$@"

--- a/docker-entrypoint_light.sh
+++ b/docker-entrypoint_light.sh
@@ -1,35 +1,7 @@
 #!/bin/sh
-
-set -e
-
-handle() {
-	SIGNAL=$(( $? - 128 ))
-	echo "Caught signal ${SIGNAL}, stopping gracefully"
-	kill -s ${SIGNAL} $(pidof node) 2>/dev/null
-}
-
-trap handle INT TERM
-
-refresh() {
-	SIGNAL=$(( $? - 128 ))
-	echo "Caught signal ${SIGNAL}, refreshing"
-	kill -s ${SIGNAL} $(pidof node) 2>/dev/null
-}
-
-trap refresh HUP
-
 if ! which -- "${1}"; then
   # first arg is not an executable
-  node /usr/src/app/ "$@" &
-	# Wait exits immediately on signals which have traps set. Store return value and wait
-	# again for all jobs to actually complete before continuing.
-	wait $! || RETVAL=$?
-	while [ ${RETVAL} = 129 ] ; do
-	  # Refressh signal HUP received. Continue waiting for signals.
-	  wait $! || RETVAL=$?
-	done
-	wait
-	exit ${RETVAL}
+  exec node /usr/src/app/ -p 80 "$@"
 fi
 
 exec "$@"


### PR DESCRIPTION
Avoid implementing a complex signal relaying mechanism in `docker-entrypoint*.sh`.
Instead, the shell scripts perform `exec node ...` and the `node` process receives the signals directly from Docker

Related to #560, #575, which were my initial implementation.