### PR TITLE
Update Dockerfile_light to fix rootless/podman

### DIFF
--- a/Dockerfile_light
+++ b/Dockerfile_light
@@ -22,14 +22,23 @@ RUN set -ex; \
 
 EXPOSE 8080
 
-RUN mkdir -p /data && chown node:node /data
+RUN mkdir -p /data; \
+    chown node:node /data; \
+    mkdir -p /usr/src/app;
+
 VOLUME /data
+
 WORKDIR /data
+
+COPY / /usr/src/app
+
+RUN cd /usr/src/app; \
+    npm install --omit=dev; \
+    chown -R root:root /usr/src/app; \
+    chmod +x /usr/src/app/docker-entrypoint.sh;
+
+USER node:node
+
 ENTRYPOINT ["/usr/src/app/docker-entrypoint.sh"]
 
-RUN mkdir -p /usr/src/app
-COPY / /usr/src/app
-RUN cd /usr/src/app && npm install --omit=dev
-RUN ["chmod", "+x", "/usr/src/app/docker-entrypoint.sh"]
-USER node:node
 HEALTHCHECK CMD node /usr/src/app/src/healthcheck.js


### PR DESCRIPTION
I found a permission issue in https://github.com/maptiler/tileserver-gl/issues/745#issuecomment-1437945933 which seems to be caused by the permissions on the 'content-type" dependency files having a high UID, non root user as owner. I was able to fix this by [chmod'ing the /usr/src/app to root](https://github.com/maptiler/tileserver-gl/blob/989944070f8229cd70268819430865f370b8f3c5/Dockerfile#L51).

However, I was doing more testing and found this issue also applies to the tileserver-light package. This updates the light dockerfile so it can work again and does some reformatting.