### PR TITLE
Handle SIGTERM

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -606,6 +606,10 @@ export function server(opts) {
     process.exit();
   });
 
+  process.on('SIGTERM', () => {
+    process.exit();
+  });
+
   process.on('SIGHUP', () => {
     console.log('Stopping server and reloading config');
 


### PR DESCRIPTION
Resolve #781

Testing:

```
$ docker run --detach -v $(pwd):/data -p 8080:80 --name tileserver-gl maptiler/tileserver-gl-l
ight:local --mbtiles zurich_switzerland.mbtiles
544505f228138f02fdb0a99b2c44500948af4fb061ea86e68e7ba6c98a3c189c

$ docker ps --filter "ancestor=maptiler/tileserver-gl-light:local"
CONTAINER ID   IMAGE                                COMMAND                  CREATED         STATUS                            PORTS                            NAMES
544505f22813   maptiler/tileserver-gl-light:local   "/usr/src/app/docker…"   7 seconds ago   Up 6 seconds (health: starting)   8080/tcp, 0.0.0.0:8080->80/tcp   tileserver-gl

$ docker kill --signal HUP tileserver-gl
tileserver-gl

$ docker kill --signal TERM tileserver-gl
tileserver-gl

$ docker ps --filter "ancestor=maptiler/tileserver-gl-light:local"
CONTAINER ID   IMAGE     COMMAND   CREATED   STATUS    PORTS     NAMES

$ docker logs tileserver-gl
Starting tileserver-gl v4.4.8
[INFO] Automatically creating config file for zurich_switzerland.mbtiles
[INFO] Only a basic preview style will be used.
[INFO] See documentation to learn how to create config.json file.
Run with --verbose to see the config file here.
Starting server
Listening at http://[::]:8080/
Startup complete
Stopping server and reloading config
Starting server
Listening at http://[::]:8080/
Startup complete
GET /health 200 2 - 3.961 ms
```