### PR TITLE
fix: Failed to open X display when restarting container

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 if ! which -- "${1}"; then
   # first arg is not an executable
+  rm /tmp/.X99-lock -f > /dev/null || ``
   export DISPLAY=:99
   Xvfb "${DISPLAY}" -nolisten unix &
   exec node /usr/src/app/ "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,10 +1,7 @@
 #!/bin/sh
 if ! which -- "${1}"; then
   # first arg is not an executable
-  if [ -e /tmp/.X99-lock ]
-  then
-    rm /tmp/.X99-lock -f
-  fi
+  if [ -e /tmp/.X99-lock ]; then rm /tmp/.X99-lock -f; fi
   export DISPLAY=:99
   Xvfb "${DISPLAY}" -nolisten unix &
   exec node /usr/src/app/ "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,7 +1,10 @@
 #!/bin/sh
 if ! which -- "${1}"; then
   # first arg is not an executable
-  rm /tmp/.X99-lock -f > /dev/null || ``
+  if [ -e /tmp/.X99-lock ]
+  then
+    rm /tmp/.X99-lock -f
+  fi
   export DISPLAY=:99
   Xvfb "${DISPLAY}" -nolisten unix &
   exec node /usr/src/app/ "$@"


### PR DESCRIPTION
fix error:

what(): Failed to open X display

by deleting the .X99-lock file at the start of the container