### PR TITLE
docs: fix link markup in endpoints.rst

### DIFF
--- a/docs/endpoints.rst
+++ b/docs/endpoints.rst
@@ -39,7 +39,7 @@ Static images
 
     * e.g. ``5.9,45.8|5.9,47.8|10.5,47.8|10.5,45.8|5.9,45.8``
     * can be provided multiple times
-    * or pass the path as per [Maptiler Cloud API](https://docs.maptiler.com/cloud/api/static-maps/)
+    * or pass the path as per `Maptiler Cloud API <https://docs.maptiler.com/cloud/api/static-maps/>`_
     * Match pattern: ((fill|stroke|width)\:[^\|]+\|)*((enc:.+)|((-?\d+\.?\d*,-?\d+\.?\d*\|)+(-?\d+\.?\d*,-?\d+\.?\d*)))
 
   * ``latlng`` - indicates coordinates are in ``lat,lng`` order rather than the usual ``lng,lat``


### PR DESCRIPTION
Hello, this is just a small markup fix. There was a Markdown link markup in the reStructuredText file.

- Site: Available endpoints — TileServer GL 1.0 documentation - https://maptiler-tileserver.readthedocs.io/en/latest/endpoints.html#static-images
- File: https://github.com/maptiler/tileserver-gl/blob/master/docs/endpoints.rst

**Before**
<img width="854" alt="Screenshot 2023-08-23 at 11 33 29" src="https://github.com/maptiler/tileserver-gl/assets/1425259/ca87b76a-222d-4c84-89c7-64c5d6ed5aaf">

**After**
<img width="882" alt="Screenshot 2023-08-23 at 11 33 18" src="https://github.com/maptiler/tileserver-gl/assets/1425259/e013a90d-b0c9-4b3f-a9c4-6494bbd4b61f">
