### PR TITLE
chore: cleanup useless decodeURIComponent() calls

### DIFF
--- a/docs/endpoints.rst
+++ b/docs/endpoints.rst
@@ -35,7 +35,7 @@ Static images
 
 * All the static image endpoints additionally support following query parameters:
 
-  * ``path`` - ``((fill|stroke|width)\:[^\|]+\|)*((enc:.+)|((-?\d+\.?\d*,-?\d+\.?\d*\|)+(-?\d+\.?\d*,-?\d+\.?\d*)))``
+  * ``path`` - ``((fill|stroke|width)\:[^\|]+\|)*(enc:.+|-?\d+(\.\d*)?,-?\d+(\.\d*)?(\|-?\d+(\.\d*)?,-?\d+(\.\d*)?)+)``
 
     * comma-separated ``lng,lat``, pipe-separated pairs
 
@@ -50,7 +50,7 @@ Static images
 
       * e.g. ``path=stroke:yellow|width:2|fill:green|5.9,45.8|5.9,47.8|10.5,47.8|10.5,45.8|5.9,45.8`` or ``path=stroke:blue|width:1|fill:yellow|enc:_p~iF~ps|U_ulLnnqC_mqNvxq`@``
 
-    * can be provided multiple times  
+    * can be provided multiple times
 
   * ``latlng`` - indicates coordinates are in ``lat,lng`` order rather than the usual ``lng,lat``
   * ``fill`` - color to use as the fill (e.g. ``red``, ``rgba(255,255,255,0.5)``, ``#0000ff``)

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -158,10 +158,7 @@ const extractPathsFromQuery = (query, transformer) => {
     // Iterate through paths, parse and validate them
     for (const providedPath of providedPaths) {
       // Logic for pushing coords to path when path includes google polyline
-      if (
-        providedPath.includes('enc:') &&
-        PATH_PATTERN.test(decodeURIComponent(providedPath))
-      ) {
+      if (providedPath.includes('enc:') && PATH_PATTERN.test(providedPath)) {
         // +4 because 'enc:' is 4 characters, everything after 'enc:' is considered to be part of the polyline
         const encIndex = providedPath.indexOf('enc:') + 4;
         const coords = polyline
@@ -432,7 +429,7 @@ const drawMarkers = async (ctx, markers, z) => {
  * @param {number} z Map zoom level.
  */
 const drawPath = (ctx, path, query, pathQuery, z) => {
-  const splitPaths = decodeURIComponent(pathQuery).split('|');
+  const splitPaths = pathQuery.split('|');
 
   if (!path || path.length < 2) {
     return null;

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -22,7 +22,7 @@ import { getFontsPbf, getTileUrls, fixTileJSONCenter } from './utils.js';
 
 const FLOAT_PATTERN = '[+-]?(?:\\d+|\\d+.?\\d+)';
 const PATH_PATTERN =
-  /^((fill|stroke|width)\:[^\|]+\|)*(enc:.+|(-?\d+(\.\d*)?,-?\d+(\.\d*)?\|)+(-?\d+(\.\d*)?,-?\d+(\.\d*)?)*)/;
+  /^((fill|stroke|width)\:[^\|]+\|)*(enc:.+|-?\d+(\.\d*)?,-?\d+(\.\d*)?(\|-?\d+(\.\d*)?,-?\d+(\.\d*)?)+)/;
 const httpTester = /^\/\//;
 
 const mercator = new SphericalMercator();

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -22,8 +22,8 @@ import { getFontsPbf, getTileUrls, fixTileJSONCenter } from './utils.js';
 
 const FLOAT_PATTERN = '[+-]?(?:\\d+|\\d+.?\\d+)';
 const PATH_PATTERN =
-  /^((fill|stroke|width)\:[^\|]+\|)*((enc:.+)|((-?\d+\.?\d*,-?\d+\.?\d*\|)+(-?\d+\.?\d*,-?\d+\.?\d*)))/;
-const httpTester = /^(http(s)?:)?\/\//;
+  /^((fill|stroke|width)\:[^\|]+\|)*(enc:.+|(-?\d+(\.\d*)?,-?\d+(\.\d*)?\|)+(-?\d+(\.\d*)?,-?\d+(\.\d*)?)*)/;
+const httpTester = /^\/\//;
 
 const mercator = new SphericalMercator();
 const getScale = (scale) => (scale || '@1x').slice(1, 2) | 0;

--- a/src/serve_style.js
+++ b/src/serve_style.js
@@ -9,7 +9,7 @@ import { validate } from '@maplibre/maplibre-gl-style-spec';
 
 import { getPublicUrl } from './utils.js';
 
-const httpTester = /^(http(s)?:)?\/\//;
+const httpTester = /^\/\//;
 
 const fixUrl = (req, url, publicUrl, opt_nokey) => {
   if (!url || typeof url !== 'string' || url.indexOf('local://') !== 0) {

--- a/test/static.js
+++ b/test/static.js
@@ -180,7 +180,7 @@ describe('Static endpoints', function () {
           200,
           2,
           /image\/png/,
-          '?path=' + decodeURIComponent('enc:{{biGwvyGoUi@s_A|{@'),
+          '?path=' + encodeURIComponent('enc:{{biGwvyGoUi@s_A|{@'),
         );
       });
     });


### PR DESCRIPTION
This is a slight simplification of the code.
The explanation is here: https://github.com/maptiler/tileserver-gl/issues/981#issuecomment-1735675052

I tested it very basically. I just looked at a few static maps from my history.