### PR TITLE
Add support for stylized attribution text for static images

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -140,7 +140,13 @@ It is recommended to also use the ``serveAllFonts`` option when using this optio
 -----------
 
 Optional string to be rendered into the raster tiles (and static maps) as watermark (bottom-left corner).
-Can be used for hard-coding attributions etc. (can also be specified per-style).
+Not used by default.
+
+``staticAttributionText``
+-----------
+
+Optional string to be rendered in the static images endpoint. Text will be rendered in the bottom-right corner,
+and styled similar to attribution on web-based maps (text only, links not supported).
 Not used by default.
 
 ``allowRemoteMarkerIcons``

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -33,6 +33,7 @@ Example:
       "serveAllStyles": false,
       "serveStaticMaps": true,
       "allowRemoteMarkerIcons": true,
+      "staticAttributionText": "© OpenMapTiles  © OpenStreetMaps",
       "tileMargin": 0
     },
     "styles": {

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -776,13 +776,13 @@ export const serve_rendered = {
             const ctx = canvas.getContext('2d');
             ctx.scale(scale, scale);
 
-            ctx.font = '12px sans-serif';
+            ctx.font = '10px sans-serif';
             const text = item.attributionText;
             const textMetrics = ctx.measureText(text);
             const textWidth = textMetrics.width;
             const textHeight = 14;
 
-            const padding = 10;
+            const padding = 6;
             ctx.fillStyle = 'rgba(255, 255, 255, 0.8)';
             ctx.fillRect(width - textWidth - padding, height - textHeight - padding, textWidth + padding, textHeight + padding);
             ctx.fillStyle = 'rgba(0,0,0,.8)';

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -1407,7 +1407,8 @@ export const serve_rendered = {
       dataProjWGStoInternalWGS: null,
       lastModified: new Date().toUTCString(),
       watermark: params.watermark || options.watermark,
-      staticAttributionText: params.staticAttributionText || options.staticAttributionText,
+      staticAttributionText:
+        params.staticAttributionText || options.staticAttributionText,
     };
     repo[id] = repoobj;
 

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -771,7 +771,7 @@ export const serve_rendered = {
             composite_array.push({ input: canvas.toBuffer() });
           }
 
-          if (item.attributionText) {
+          if (opt_mode === 'static' && item.attributionText) {
             const canvas = createCanvas(scale * width, scale * height);
             const ctx = canvas.getContext('2d');
             ctx.scale(scale, scale);

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -771,13 +771,13 @@ export const serve_rendered = {
             composite_array.push({ input: canvas.toBuffer() });
           }
 
-          if (opt_mode === 'static' && item.attributionText) {
+          if (opt_mode === 'static' && item.staticAttributionText) {
             const canvas = createCanvas(scale * width, scale * height);
             const ctx = canvas.getContext('2d');
             ctx.scale(scale, scale);
 
             ctx.font = '10px sans-serif';
-            const text = item.attributionText;
+            const text = item.staticAttributionText;
             const textMetrics = ctx.measureText(text);
             const textWidth = textMetrics.width;
             const textHeight = 14;
@@ -792,7 +792,7 @@ export const serve_rendered = {
             );
             ctx.fillStyle = 'rgba(0,0,0,.8)';
             ctx.fillText(
-              item.attributionText,
+              item.staticAttributionText,
               width - textWidth - padding / 2,
               height - textHeight + 8,
             );
@@ -1407,7 +1407,7 @@ export const serve_rendered = {
       dataProjWGStoInternalWGS: null,
       lastModified: new Date().toUTCString(),
       watermark: params.watermark || options.watermark,
-      attributionText: params.attributionText || options.attributionText,
+      staticAttributionText: params.staticAttributionText || options.staticAttributionText,
     };
     repo[id] = repoobj;
 

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -784,9 +784,18 @@ export const serve_rendered = {
 
             const padding = 6;
             ctx.fillStyle = 'rgba(255, 255, 255, 0.8)';
-            ctx.fillRect(width - textWidth - padding, height - textHeight - padding, textWidth + padding, textHeight + padding);
+            ctx.fillRect(
+              width - textWidth - padding,
+              height - textHeight - padding,
+              textWidth + padding,
+              textHeight + padding,
+            );
             ctx.fillStyle = 'rgba(0,0,0,.8)';
-            ctx.fillText(item.attributionText, width - textWidth - (padding / 2), height - textHeight + 8);
+            ctx.fillText(
+              item.attributionText,
+              width - textWidth - padding / 2,
+              height - textHeight + 8,
+            );
 
             composite_array.push({ input: canvas.toBuffer() });
           }

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -771,6 +771,26 @@ export const serve_rendered = {
             composite_array.push({ input: canvas.toBuffer() });
           }
 
+          if (item.attributionText) {
+            const canvas = createCanvas(scale * width, scale * height);
+            const ctx = canvas.getContext('2d');
+            ctx.scale(scale, scale);
+
+            ctx.font = '12px sans-serif';
+            const text = item.attributionText;
+            const textMetrics = ctx.measureText(text);
+            const textWidth = textMetrics.width;
+            const textHeight = 14;
+
+            const padding = 10;
+            ctx.fillStyle = 'rgba(255, 255, 255, 0.8)';
+            ctx.fillRect(width - textWidth - padding, height - textHeight - padding, textWidth + padding, textHeight + padding);
+            ctx.fillStyle = 'rgba(0,0,0,.8)';
+            ctx.fillText(item.attributionText, width - textWidth - (padding / 2), height - textHeight + 8);
+
+            composite_array.push({ input: canvas.toBuffer() });
+          }
+
           if (composite_array.length > 0) {
             image.composite(composite_array);
           }
@@ -1378,6 +1398,7 @@ export const serve_rendered = {
       dataProjWGStoInternalWGS: null,
       lastModified: new Date().toUTCString(),
       watermark: params.watermark || options.watermark,
+      attributionText: params.attributionText || options.attributionText,
     };
     repo[id] = repoobj;
 


### PR DESCRIPTION
Adds a new config option `staticAttributionText` that is used for generating the attribution in the static images API.

Open to any suggestions on the option naming, or styling choices. Tried to keep the style as close to default web attribution as possible.

Here's what the `staticAttributionText` looks like:

![image](https://github.com/maptiler/tileserver-gl/assets/814934/e0f53fac-6fbf-4253-ae25-6e6f9b098d78)


Here's what the default `watermark` looks like:

![image](https://github.com/maptiler/tileserver-gl/assets/814934/b3b8f374-63e7-4c84-9ad3-c8427a829d37)
