### PR TITLE
Allow base 64 url as images for static maps

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -157,6 +157,13 @@ Allows the rendering of marker icons fetched via http(s) hyperlinks.
 For security reasons only allow this if you can control the origins from where the markers are fetched!
 Default is to disallow fetching of icons from remote sources.
 
+``allowInlineMarkerImages``
+--------------
+Allows the rendering of inline marker icons or base64 urls.
+For security reasons only allow this if you can control the origins from where the markers are fetched!
+Not used by default.
+
+
 ``styles``
 ==========
 

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -294,6 +294,8 @@ const extractMarkersFromQuery = (query, options, transformer) => {
       // When we encounter a remote icon check if the configuration explicitly allows them.
     } else if (options.allowRemoteMarkerIcons !== true) {
       continue;
+    } else if (options.allowInlineMarkerImages !== true) {
+      continue;
     }
 
     // Ensure marker location could be parsed

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -279,7 +279,8 @@ const extractMarkersFromQuery = (query, options, transformer) => {
     let iconURI = markerParts[1];
     // Check if icon is served via http otherwise marker icons are expected to
     // be provided as filepaths relative to configured icon path
-    const isRemoteURL = iconURI.startsWith('http://') || iconURI.startsWith('https://');
+    const isRemoteURL =
+      iconURI.startsWith('http://') || iconURI.startsWith('https://');
     const isDataURL = iconURI.startsWith('data:');
     if (!(isRemoteURL || isDataURL)) {
       // Sanitize URI with sanitize-filename

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -279,7 +279,7 @@ const extractMarkersFromQuery = (query, options, transformer) => {
     let iconURI = markerParts[1];
     // Check if icon is served via http otherwise marker icons are expected to
     // be provided as filepaths relative to configured icon path
-    if (!(iconURI.startsWith('http://') || iconURI.startsWith('https://'))) {
+    if (!(iconURI.startsWith('http://') || iconURI.startsWith('https://') || iconURI.startsWith('data:'))) {
       // Sanitize URI with sanitize-filename
       // https://www.npmjs.com/package/sanitize-filename#details
       iconURI = sanitize(iconURI);

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -279,7 +279,9 @@ const extractMarkersFromQuery = (query, options, transformer) => {
     let iconURI = markerParts[1];
     // Check if icon is served via http otherwise marker icons are expected to
     // be provided as filepaths relative to configured icon path
-    if (!(iconURI.startsWith('http://') || iconURI.startsWith('https://') || iconURI.startsWith('data:'))) {
+    const isRemoteURL = iconURI.startsWith('http://') || iconURI.startsWith('https://');
+    const isDataURL = iconURI.startsWith('data:');
+    if (!(isRemoteURL || isDataURL)) {
       // Sanitize URI with sanitize-filename
       // https://www.npmjs.com/package/sanitize-filename#details
       iconURI = sanitize(iconURI);
@@ -292,9 +294,9 @@ const extractMarkersFromQuery = (query, options, transformer) => {
       iconURI = path.resolve(options.paths.icons, iconURI);
 
       // When we encounter a remote icon check if the configuration explicitly allows them.
-    } else if (options.allowRemoteMarkerIcons !== true) {
+    } else if (isRemoteURL && options.allowRemoteMarkerIcons !== true) {
       continue;
-    } else if (options.allowInlineMarkerImages !== true) {
+    } else if (isDataURL && options.allowInlineMarkerImages !== true) {
       continue;
     }
 


### PR DESCRIPTION
An extension of https://github.com/maptiler/tileserver-gl/pull/619 to allow Base64 images to be rendered to static maps.

Also added `allowInlineMarkerImages` config to enable or disable the feature. Open to other variable names