### PR TITLE
Fixed Issue #1025 - URL-based glyphs and fonts break displaying of ve…

### DIFF
--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -33,7 +33,7 @@ import {
 const FLOAT_PATTERN = '[+-]?(?:\\d+|\\d+.?\\d+)';
 const PATH_PATTERN =
   /^((fill|stroke|width)\:[^\|]+\|)*(enc:.+|-?\d+(\.\d*)?,-?\d+(\.\d*)?(\|-?\d+(\.\d*)?,-?\d+(\.\d*)?)+)/;
-const httpTester = /^\/\//;
+const httpTester = /^(http(s)?:)?\/\//;
 
 const mercator = new SphericalMercator();
 const getScale = (scale) => (scale || '@1x').slice(1, 2) | 0;

--- a/src/serve_style.js
+++ b/src/serve_style.js
@@ -9,7 +9,7 @@ import { validate } from '@maplibre/maplibre-gl-style-spec';
 
 import { getPublicUrl } from './utils.js';
 
-const httpTester = /^\/\//;
+const httpTester = /^(http(s)?:)?\/\//;
 
 const fixUrl = (req, url, publicUrl, opt_nokey) => {
   if (!url || typeof url !== 'string' || url.indexOf('local://') !== 0) {


### PR DESCRIPTION
Fixed Issue #1025 - URL-based glyphs and fonts break displaying of vector tiles
    
**Root cause**: modified regex in #1002 caused URLs to be broken.
**Fixed**: by reverting previous regexes.
    
#### Tests:
 * Confirmed by building and running locally (via Dockerfile) with data folder which breaks on 4.6.0
 * Run tests via Dockerfile_test
