### PR TITLE
Clean error message, remove outdated data wmts

### DIFF
--- a/public/templates/index.tmpl
+++ b/public/templates/index.tmpl
@@ -82,9 +82,6 @@
             <div class="identifier">type: {{#is_vector}}vector{{/is_vector}}{{^is_vector}}raster{{/is_vector}} data {{#if source_type}} | ext: {{source_type}}{{/if}}</div>
             <p class="services">
               services: <a href="{{public_url}}data/{{@key}}.json{{&../key_query}}">TileJSON</a>
-              {{#if wmts_link}}
-                | <a href="{{&wmts_link}}">WMTS</a>
-              {{/if}}
               {{#if xyz_link}}
                 | <a href="#" onclick="return toggle_xyz('xyz_data_{{@key}}');">XYZ</a>
                   <input id="xyz_data_{{@key}}" type="text" value="{{&xyz_link}}" style="display:none;" />

--- a/src/serve_style.js
+++ b/src/serve_style.js
@@ -98,9 +98,7 @@ export const serve_style = {
 
     const validationErrors = validate(styleFileData);
     if (validationErrors.length > 0) {
-      console.log(
-        `The file "${params.style}" is not valid a valid style file:`,
-      );
+      console.log(`The file "${params.style}" is not a valid style file:`);
       for (const err of validationErrors) {
         console.log(`${err.line}: ${err.message}`);
       }


### PR DESCRIPTION
On the index page, the WTMS link in the Data section can never be displayed.
It seems to be a remnant of very early days.
It used to point to Maptiler servers, just like the WMTS link in the Style sections used to.