### PR TITLE
Simplify alpha premultiplication, now supported by sharp

### DIFF
--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -428,24 +428,9 @@ const respondImage = (
         return res.status(500).header('Content-Type', 'text/plain').send(err);
       }
 
-      // Fix semi-transparent outlines on raw, premultiplied input
-      // https://github.com/maptiler/tileserver-gl/issues/350#issuecomment-477857040
-      for (let i = 0; i < data.length; i += 4) {
-        const alpha = data[i + 3];
-        const norm = alpha / 255;
-        if (alpha === 0) {
-          data[i] = 0;
-          data[i + 1] = 0;
-          data[i + 2] = 0;
-        } else {
-          data[i] = data[i] / norm;
-          data[i + 1] = data[i + 1] / norm;
-          data[i + 2] = data[i + 2] / norm;
-        }
-      }
-
       const image = sharp(data, {
         raw: {
+          premultiplied: true,
           width: params.width * scale,
           height: params.height * scale,
           channels: 4,


### PR DESCRIPTION
Maplibre-native outputs premultiplied pixels values. The sharp library did not support it so we added code to cancel the alpha premultiplication. Note that this can only visible on raster tiles (and probably static maps).

The sharp library now supports premultiplied pixels with the right config. Let's use it: it should be faster and easier to maintain.

Feature announced here:
https://github.com/lovell/sharp/issues/1599#issuecomment-837004081

Feature developped here by @mnutt:
https://github.com/lovell/sharp/pull/2685

## Raster Before
![image](https://github.com/liberty-rider/tileserver-gl/assets/242172/da1691b3-b56c-44c9-9d04-4c1af163feb8)

## Raster After (visually identical)
![image](https://github.com/liberty-rider/tileserver-gl/assets/242172/444059de-51e8-484a-b9fa-a3eb35c54912)

## Vector for comparison (with building shadow)
![image](https://github.com/liberty-rider/tileserver-gl/assets/242172/dedc1538-4762-4f44-bd10-918c45eaba4b)

## What the problem used to look like
For reference, here is the same zone when premultiplication is not cancelled and `premultiplied: true` is not set.
![image](https://github.com/liberty-rider/tileserver-gl/assets/242172/186bfb9c-8a12-4aa3-9836-70c5409c53ab)
