### PR TITLE
Code cleaning: more idiomatic, a bit shorter

### DIFF
--- a/public/templates/index.tmpl
+++ b/public/templates/index.tmpl
@@ -79,7 +79,7 @@
           <div class="details">
             <h3>{{tileJSON.name}}</h3>
             <div class="identifier">identifier: {{@key}}{{#if formatted_filesize}} | size: {{formatted_filesize}}{{/if}}</div>
-            <div class="identifier">type: {{#is_vector}}vector{{/is_vector}}{{^is_vector}}raster{{/is_vector}} data {{#if source_type}} | ext: {{source_type}}{{/if}}</div>
+            <div class="identifier">type: {{#is_vector}}vector{{/is_vector}}{{^is_vector}}raster{{/is_vector}} data {{#if sourceType}} | ext: {{sourceType}}{{/if}}</div>
             <p class="services">
               services: <a href="{{public_url}}data/{{@key}}.json{{&../key_query}}">TileJSON</a>
               {{#if xyz_link}}

--- a/src/main.js
+++ b/src/main.js
@@ -241,7 +241,7 @@ const StartWithInputFile = async (inputFile) => {
   }
 };
 
-fs.stat(path.resolve(opts.config), (err, stats) => {
+fs.stat(path.resolve(opts.config), async (err, stats) => {
   if (err || !stats.isFile() || stats.size === 0) {
     let inputFile;
     if (opts.file) {
@@ -274,21 +274,22 @@ fs.stat(path.resolve(opts.config), (err, stats) => {
         const writer = fs.createWriteStream(filename);
         console.log(`No input file found`);
         console.log(`[DEMO] Downloading sample data (${filename}) from ${url}`);
-        axios({
-          url,
-          method: 'GET',
-          responseType: 'stream',
-        })
-          .then((response) => {
-            response.data.pipe(writer);
-            writer.on('finish', () => StartWithInputFile(filename));
-            writer.on('error', (err) =>
-              console.error(`Error writing file: ${err}`),
-            );
-          })
-          .catch((error) => {
-            console.error(`Error downloading file: ${error}`);
+
+        try {
+          const response = await axios({
+            url,
+            method: 'GET',
+            responseType: 'stream',
           });
+
+          response.data.pipe(writer);
+          writer.on('finish', () => StartWithInputFile(filename));
+          writer.on('error', (err) =>
+            console.error(`Error writing file: ${err}`),
+          );
+        } catch (error) {
+          console.error(`Error downloading file: ${error}`);
+        }
       }
     }
   } else {

--- a/src/main.js
+++ b/src/main.js
@@ -68,8 +68,8 @@ const StartServer = (configPath, config) => {
     publicUrl += '/';
   }
   return server({
-    configPath: configPath,
-    config: config,
+    configPath,
+    config,
     bind: opts.bind,
     port: opts.port,
     cors: opts.cors,
@@ -77,7 +77,7 @@ const StartServer = (configPath, config) => {
     silent: opts.silent,
     logFile: opts.log_file,
     logFormat: opts.log_format,
-    publicUrl: publicUrl,
+    publicUrl,
   });
 };
 
@@ -215,7 +215,7 @@ const StartWithInputFile = async (inputFile) => {
               config['styles'][styleName] = {
                 style: styleFileRel,
                 tilejson: {
-                  bounds: bounds,
+                  bounds,
                 },
               };
             }

--- a/src/pmtiles_adapter.js
+++ b/src/pmtiles_adapter.js
@@ -11,7 +11,7 @@ class PMTilesFileSource {
   }
   async getBytes(offset, length) {
     const buffer = Buffer.alloc(length);
-    await ReadFileBytes(this.fd, buffer, offset);
+    await readFileBytes(this.fd, buffer, offset);
     const ab = buffer.buffer.slice(
       buffer.byteOffset,
       buffer.byteOffset + buffer.byteLength,
@@ -26,7 +26,7 @@ class PMTilesFileSource {
  * @param buffer
  * @param offset
  */
-async function ReadFileBytes(fd, buffer, offset) {
+async function readFileBytes(fd, buffer, offset) {
   return new Promise((resolve, reject) => {
     fs.read(fd, buffer, 0, buffer.length, offset, (err) => {
       if (err) {
@@ -41,7 +41,7 @@ async function ReadFileBytes(fd, buffer, offset) {
  *
  * @param FilePath
  */
-export function PMtilesOpen(FilePath) {
+export function openPMtiles(FilePath) {
   let pmtiles = undefined;
 
   if (isValidHttpUrl(FilePath)) {
@@ -59,12 +59,12 @@ export function PMtilesOpen(FilePath) {
  *
  * @param pmtiles
  */
-export async function GetPMtilesInfo(pmtiles) {
+export async function getPMtilesInfo(pmtiles) {
   const header = await pmtiles.getHeader();
   const metadata = await pmtiles.getMetadata();
 
   //Add missing metadata from header
-  metadata['format'] = GetPmtilesTileType(header.tileType).type;
+  metadata['format'] = getPmtilesTileType(header.tileType).type;
   metadata['minzoom'] = header.minZoom;
   metadata['maxzoom'] = header.maxZoom;
 
@@ -103,23 +103,23 @@ export async function GetPMtilesInfo(pmtiles) {
  * @param x
  * @param y
  */
-export async function GetPMtilesTile(pmtiles, z, x, y) {
+export async function getPMtilesTile(pmtiles, z, x, y) {
   const header = await pmtiles.getHeader();
-  const TileType = GetPmtilesTileType(header.tileType);
+  const tileType = getPmtilesTileType(header.tileType);
   let zxyTile = await pmtiles.getZxy(z, x, y);
   if (zxyTile && zxyTile.data) {
     zxyTile = Buffer.from(zxyTile.data);
   } else {
     zxyTile = undefined;
   }
-  return { data: zxyTile, header: TileType.header };
+  return { data: zxyTile, header: tileType.header };
 }
 
 /**
  *
  * @param typenum
  */
-function GetPmtilesTileType(typenum) {
+function getPmtilesTileType(typenum) {
   let head = {};
   let tileType;
   switch (typenum) {

--- a/src/serve_data.js
+++ b/src/serve_data.js
@@ -12,9 +12,9 @@ import { VectorTile } from '@mapbox/vector-tile';
 
 import { getTileUrls, isValidHttpUrl, fixTileJSONCenter } from './utils.js';
 import {
-  PMtilesOpen,
-  GetPMtilesInfo,
-  GetPMtilesTile,
+  openPMtiles,
+  getPMtilesInfo,
+  getPMtilesTile,
 } from './pmtiles_adapter.js';
 
 export const serve_data = {
@@ -53,8 +53,8 @@ export const serve_data = {
         ) {
           return res.status(404).send('Out of bounds');
         }
-        if (item.source_type === 'pmtiles') {
-          let tileinfo = await GetPMtilesTile(item.source, z, x, y);
+        if (item.sourceType === 'pmtiles') {
+          let tileinfo = await getPMtilesTile(item.source, z, x, y);
           if (tileinfo == undefined || tileinfo.data == undefined) {
             return res.status(404).send('Not found');
           } else {
@@ -99,7 +99,7 @@ export const serve_data = {
 
             return res.status(200).send(data);
           }
-        } else if (item.source_type === 'mbtiles') {
+        } else if (item.sourceType === 'mbtiles') {
           item.source.getTile(z, x, y, (err, data, headers) => {
             let isGzipped;
             if (err) {
@@ -223,11 +223,11 @@ export const serve_data = {
     }
 
     let source;
-    let source_type;
+    let sourceType;
     if (inputType === 'pmtiles') {
-      source = PMtilesOpen(inputFile);
-      source_type = 'pmtiles';
-      const metadata = await GetPMtilesInfo(source);
+      source = openPMtiles(inputFile);
+      sourceType = 'pmtiles';
+      const metadata = await getPMtilesInfo(source);
 
       tileJSON['name'] = id;
       tileJSON['format'] = 'pbf';
@@ -245,7 +245,7 @@ export const serve_data = {
         tileJSON = options.dataDecoratorFunc(id, 'tilejson', tileJSON);
       }
     } else if (inputType === 'mbtiles') {
-      source_type = 'mbtiles';
+      sourceType = 'mbtiles';
       const sourceInfoPromise = new Promise((resolve, reject) => {
         source = new MBTiles(inputFile + '?mode=ro', (err) => {
           if (err) {
@@ -285,7 +285,7 @@ export const serve_data = {
       tileJSON,
       publicUrl,
       source,
-      source_type,
+      sourceType,
     };
   },
 };

--- a/src/serve_font.js
+++ b/src/serve_font.js
@@ -4,7 +4,7 @@ import express from 'express';
 
 import { getFontsPbf, listFonts } from './utils.js';
 
-export const serve_font = (options, allowedFonts) => {
+export const serve_font = async (options, allowedFonts) => {
   const app = express().disable('x-powered-by');
 
   const lastModified = new Date().toUTCString();
@@ -13,25 +13,29 @@ export const serve_font = (options, allowedFonts) => {
 
   const existingFonts = {};
 
-  app.get('/fonts/:fontstack/:range([\\d]+-[\\d]+).pbf', (req, res, next) => {
-    const fontstack = decodeURI(req.params.fontstack);
-    const range = req.params.range;
+  app.get(
+    '/fonts/:fontstack/:range([\\d]+-[\\d]+).pbf',
+    async (req, res, next) => {
+      const fontstack = decodeURI(req.params.fontstack);
+      const range = req.params.range;
 
-    getFontsPbf(
-      options.serveAllFonts ? null : allowedFonts,
-      fontPath,
-      fontstack,
-      range,
-      existingFonts,
-    ).then(
-      (concated) => {
+      try {
+        const concatenated = await getFontsPbf(
+          options.serveAllFonts ? null : allowedFonts,
+          fontPath,
+          fontstack,
+          range,
+          existingFonts,
+        );
+
         res.header('Content-type', 'application/x-protobuf');
         res.header('Last-Modified', lastModified);
-        return res.send(concated);
-      },
-      (err) => res.status(400).header('Content-Type', 'text/plain').send(err),
-    );
-  });
+        return res.send(concatenated);
+      } catch (err) {
+        res.status(400).header('Content-Type', 'text/plain').send(err);
+      }
+    },
+  );
 
   app.get('/fonts.json', (req, res, next) => {
     res.header('Content-type', 'application/json');
@@ -40,8 +44,7 @@ export const serve_font = (options, allowedFonts) => {
     );
   });
 
-  return listFonts(options.paths.fonts).then((fonts) => {
-    Object.assign(existingFonts, fonts);
-    return app;
-  });
+  const fonts = await listFonts(options.paths.fonts);
+  Object.assign(existingFonts, fonts);
+  return app;
 };

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -573,19 +573,10 @@ export const serve_rendered = {
           ],
           z,
         );
+
+        // prettier-ignore
         return respondImage(
-          options,
-          item,
-          z,
-          tileCenter[0],
-          tileCenter[1],
-          0,
-          0,
-          tileSize,
-          tileSize,
-          scale,
-          format,
-          res,
+          options, item, z, tileCenter[0], tileCenter[1], 0, 0, tileSize, tileSize, scale, format, res,
         );
       },
     );
@@ -641,35 +632,15 @@ export const serve_rendered = {
               options,
               transformer,
             );
+
+            // prettier-ignore
             const overlay = await renderOverlay(
-              z,
-              x,
-              y,
-              bearing,
-              pitch,
-              w,
-              h,
-              scale,
-              paths,
-              markers,
-              req.query,
+              z, x, y, bearing, pitch, w, h, scale, paths, markers, req.query,
             );
 
+            // prettier-ignore
             return respondImage(
-              options,
-              item,
-              z,
-              x,
-              y,
-              bearing,
-              pitch,
-              w,
-              h,
-              scale,
-              format,
-              res,
-              overlay,
-              'static',
+              options, item, z, x, y, bearing, pitch, w, h, scale, format, res, overlay, 'static',
             );
           } catch (e) {
             next(e);
@@ -723,34 +694,15 @@ export const serve_rendered = {
             options,
             transformer,
           );
+
+          // prettier-ignore
           const overlay = await renderOverlay(
-            z,
-            x,
-            y,
-            bearing,
-            pitch,
-            w,
-            h,
-            scale,
-            paths,
-            markers,
-            req.query,
+            z, x, y, bearing, pitch, w, h, scale, paths, markers, req.query,
           );
+
+          // prettier-ignore
           return respondImage(
-            options,
-            item,
-            z,
-            x,
-            y,
-            bearing,
-            pitch,
-            w,
-            h,
-            scale,
-            format,
-            res,
-            overlay,
-            'static',
+            options, item, z, x, y, bearing, pitch, w, h, scale, format, res, overlay, 'static',
           );
         } catch (e) {
           next(e);
@@ -856,35 +808,14 @@ export const serve_rendered = {
             const x = center[0];
             const y = center[1];
 
+            // prettier-ignore
             const overlay = await renderOverlay(
-              z,
-              x,
-              y,
-              bearing,
-              pitch,
-              w,
-              h,
-              scale,
-              paths,
-              markers,
-              req.query,
+              z, x, y, bearing, pitch, w, h, scale, paths, markers, req.query,
             );
 
+            // prettier-ignore
             return respondImage(
-              options,
-              item,
-              z,
-              x,
-              y,
-              bearing,
-              pitch,
-              w,
-              h,
-              scale,
-              format,
-              res,
-              overlay,
-              'static',
+              options, item, z, x, y, bearing, pitch, w, h, scale, format, res, overlay, 'static',
             );
           } catch (e) {
             next(e);

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -97,7 +97,7 @@ function createEmptyResponse(format, color, callback) {
     raw: {
       width: 1,
       height: 1,
-      channels: channels,
+      channels,
     },
   })
     .toFormat(format)
@@ -405,10 +405,10 @@ const respondImage = (
     const params = {
       zoom: mlglZ,
       center: [lon, lat],
-      bearing: bearing,
-      pitch: pitch,
-      width: width,
-      height: height,
+      bearing,
+      pitch,
+      width,
+      height,
     };
 
     if (z === 0) {
@@ -856,8 +856,8 @@ export const serve_rendered = {
     const createPool = (ratio, mode, min, max) => {
       const createRenderer = (ratio, createCallback) => {
         const renderer = new mlgl.Map({
-          mode: mode,
-          ratio: ratio,
+          mode,
+          ratio,
           request: async (req, callback) => {
             const protocol = req.url.split(':')[0];
             // console.log('Handling request:', req);
@@ -1016,8 +1016,8 @@ export const serve_rendered = {
         createCallback(null, renderer);
       };
       return new advancedPool.Pool({
-        min: min,
-        max: max,
+        min,
+        max,
         create: createRenderer.bind(null, ratio),
         destroy: (renderer) => {
           renderer.release();
@@ -1114,9 +1114,9 @@ export const serve_rendered = {
 
         let inputFile;
         const DataInfo = dataResolver(dataId);
-        if (DataInfo.inputfile) {
-          inputFile = DataInfo.inputfile;
-          source_type = DataInfo.filetype;
+        if (DataInfo.inputFile) {
+          inputFile = DataInfo.inputFile;
+          source_type = DataInfo.fileType;
         } else {
           console.error(`ERROR: data "${inputFile}" not found!`);
           process.exit(1);

--- a/src/serve_style.js
+++ b/src/serve_style.js
@@ -11,12 +11,12 @@ import { getPublicUrl } from './utils.js';
 
 const httpTester = /^(http(s)?:)?\/\//;
 
-const fixUrl = (req, url, publicUrl, opt_nokey) => {
+const fixUrl = (req, url, publicUrl) => {
   if (!url || typeof url !== 'string' || url.indexOf('local://') !== 0) {
     return url;
   }
   const queryParams = [];
-  if (!opt_nokey && req.query.key) {
+  if (req.query.key) {
     queryParams.unshift(`key=${encodeURIComponent(req.query.key)}`);
   }
   let query = '';
@@ -42,20 +42,10 @@ export const serve_style = {
       }
       // mapbox-gl-js viewer cannot handle sprite urls with query
       if (styleJSON_.sprite) {
-        styleJSON_.sprite = fixUrl(
-          req,
-          styleJSON_.sprite,
-          item.publicUrl,
-          false,
-        );
+        styleJSON_.sprite = fixUrl(req, styleJSON_.sprite, item.publicUrl);
       }
       if (styleJSON_.glyphs) {
-        styleJSON_.glyphs = fixUrl(
-          req,
-          styleJSON_.glyphs,
-          item.publicUrl,
-          false,
-        );
+        styleJSON_.glyphs = fixUrl(req, styleJSON_.glyphs, item.publicUrl);
       }
       return res.send(styleJSON_);
     });

--- a/src/server.js
+++ b/src/server.js
@@ -141,11 +141,8 @@ function start(opts) {
 
   // Load all available icons into a settings object
   startupPromises.push(
-    new Promise((resolve) => {
-      getFiles(paths.icons).then((files) => {
-        paths.availableIcons = files;
-        resolve();
-      });
+    getFiles(paths.icons).then((files) => {
+      paths.availableIcons = files;
     }),
   );
 

--- a/src/server.js
+++ b/src/server.js
@@ -253,7 +253,7 @@ function start(opts) {
                 inputFile = path.resolve(options.paths[fileType], inputFile);
               }
 
-              return { inputfile: inputFile, filetype: fileType };
+              return { inputFile, fileType };
             },
           ),
         );
@@ -344,7 +344,7 @@ function start(opts) {
       result.push({
         version: styleJSON.version,
         name: styleJSON.name,
-        id: id,
+        id,
         url: `${getPublicUrl(
           opts.publicUrl,
           req,
@@ -630,9 +630,9 @@ function start(opts) {
   enableShutdown(server);
 
   return {
-    app: app,
-    server: server,
-    startupPromise: startupPromise,
+    app,
+    server,
+    startupPromise,
   };
 }
 

--- a/src/server.js
+++ b/src/server.js
@@ -179,15 +179,15 @@ function start(opts) {
         item,
         id,
         opts.publicUrl,
-        (StyleSourceId, protocol) => {
+        (styleSourceId, protocol) => {
           let dataItemId;
           for (const id of Object.keys(data)) {
-            if (id === StyleSourceId) {
+            if (id === styleSourceId) {
               // Style id was found in data ids, return that id
               dataItemId = id;
             } else {
               const fileType = Object.keys(data[id])[0];
-              if (data[id][fileType] === StyleSourceId) {
+              if (data[id][fileType] === styleSourceId) {
                 // Style id was found in data filename, return the id that filename belong to
                 dataItemId = id;
               }
@@ -199,21 +199,21 @@ function start(opts) {
           } else {
             if (!allowMoreData) {
               console.log(
-                `ERROR: style "${item.style}" using unknown file "${StyleSourceId}"! Skipping...`,
+                `ERROR: style "${item.style}" using unknown file "${styleSourceId}"! Skipping...`,
               );
               return undefined;
             } else {
               let id =
-                StyleSourceId.substr(0, StyleSourceId.lastIndexOf('.')) ||
-                StyleSourceId;
-              if (isValidHttpUrl(StyleSourceId)) {
+                styleSourceId.substr(0, styleSourceId.lastIndexOf('.')) ||
+                styleSourceId;
+              if (isValidHttpUrl(styleSourceId)) {
                 id =
-                  fnv1a(StyleSourceId) + '_' + id.replace(/^.*\/(.*)$/, '$1');
+                  fnv1a(styleSourceId) + '_' + id.replace(/^.*\/(.*)$/, '$1');
               }
               while (data[id]) id += '_'; //if the data source id already exists, add a "_" untill it doesn't
               //Add the new data source to the data array.
               data[id] = {
-                [protocol]: StyleSourceId,
+                [protocol]: styleSourceId,
               };
 
               return id;
@@ -236,15 +236,15 @@ function start(opts) {
             item,
             id,
             opts.publicUrl,
-            (StyleSourceId) => {
+            function dataResolver(styleSourceId) {
               let fileType;
               let inputFile;
               for (const id of Object.keys(data)) {
                 fileType = Object.keys(data[id])[0];
-                if (StyleSourceId == id) {
+                if (styleSourceId == id) {
                   inputFile = data[id][fileType];
                   break;
-                } else if (data[id][fileType] == StyleSourceId) {
+                } else if (data[id][fileType] == styleSourceId) {
                   inputFile = data[id][fileType];
                   break;
                 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -139,7 +139,7 @@ const getFontPbf = (allowedFonts, fontPath, name, range, fallbacks) =>
     }
   });
 
-export const getFontsPbf = (
+export const getFontsPbf = async (
   allowedFonts,
   fontPath,
   names,
@@ -160,7 +160,8 @@ export const getFontsPbf = (
     );
   }
 
-  return Promise.all(queue).then((values) => glyphCompose.combine(values));
+  const values = await Promise.all(queue);
+  return glyphCompose.combine(values);
 };
 
 export const listFonts = async (fontPath) => {


### PR DESCRIPTION
Commits in this PR clean up the code in stages:
- Convert some promises to async/await in some places where .then() subsisted.
- Compact arguments for renderOverlay and respondImage (2 lines instead of 12, repeated multiple times)
- Remove duplicated field names to simplify code
- Remove unused opt_nokey arg
- Apply camelCase to function and variable names 
