### PR TITLE
Fix crash on ARM during rendering

### DIFF
--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -18,7 +18,7 @@ import path from 'path';
 import url from 'url';
 import util from 'util';
 import zlib from 'zlib';
-import sharp from 'sharp'; // sharp has to be required before node-canvas on linux but after it on windows. see https://github.com/lovell/sharp/issues/371
+import sharp from 'sharp';
 import clone from 'clone';
 import Color from 'color';
 import express from 'express';

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -1,5 +1,17 @@
 'use strict';
 
+// SECTION START
+//
+// The order of the two imports below is important.
+// For an unknown reason, if the order is reversed, rendering can crash.
+// This happens on ARM:
+//  > terminate called after throwing an instance of 'std::runtime_error'
+//  > what():  Cannot read GLX extensions.
+import 'canvas';
+import '@maplibre/maplibre-gl-native';
+//
+// SECTION END
+
 import advancedPool from 'advanced-pool';
 import fs from 'node:fs';
 import path from 'path';


### PR DESCRIPTION
The order of imports changed in PR #1062.

This causes a crash on ARM platforms during raster rendering.
To reproduce, load rendered image. The home page also triggers the crash through thumbnail rendering.

This PR fixes it, with a comment to minimize the chance of regression.