### PR TITLE
Hot-Reloading changed mbtiles

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -32,6 +32,7 @@ Example:
       "pbfAlias": "pbf",
       "serveAllFonts": false,
       "serveAllStyles": false,
+      "watchMbtiles": false,
       "serveStaticMaps": true,
       "allowRemoteMarkerIcons": true,
       "allowInlineMarkerImages": true,
@@ -151,6 +152,13 @@ Otherwise only the fonts referenced by available styles will be served.
 If this option is enabled, all the styles from the ``paths.styles`` will be served. (No recursion, only ``.json`` files are used.)
 The process will also watch for changes in this directory and remove/add more styles dynamically.
 It is recommended to also use the ``serveAllFonts`` option when using this option.
+
+``watchMbtiles``
+------------------------
+
+If this option is enabled, all the opened Mbtiles are watched for changes and automatically reloaded.
+The new data is then severed immediately. There is a small downtime for rendered endpoints.
+Mbtiles have to be replaced atomically. i.e. moving the file from the same filesystem. Modifying an existing file will crash the server.
 
 ``serveStaticMaps``
 ------------------------

--- a/src/main.js
+++ b/src/main.js
@@ -109,6 +109,7 @@ const startWithInputFile = async (inputFile) => {
 
   const config = {
     options: {
+      watchMbtiles: true,
       paths: {
         root: styleDir,
         fonts: 'fonts',

--- a/src/serve_data.js
+++ b/src/serve_data.js
@@ -189,6 +189,9 @@ export const serve_data = {
 
     return app;
   },
+  remove: (repo, id) => {
+    delete repo[id];
+  },
   add: async (options, repo, params, id, publicUrl) => {
     let inputFile;
     let inputType;

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -847,6 +847,7 @@ export const serve_rendered = {
       renderersStatic: [],
       sources: {},
       sourceTypes: {},
+      styleFile: '',
     };
 
     let styleJSON;
@@ -1023,6 +1024,7 @@ export const serve_rendered = {
     };
 
     const styleFile = params.style;
+    map.styleFile = styleFile;
     const styleJSONPath = path.resolve(options.paths.styles, styleFile);
     try {
       styleJSON = JSON.parse(fs.readFileSync(styleJSONPath));

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -1250,6 +1250,9 @@ export const serve_rendered = {
       item.map.renderersStatic.forEach((pool) => {
         pool.close();
       });
+      Object.entries(item.map.sources).forEach(([key, source]) => {
+        delete item.map.sources[key];
+      });
     }
     delete repo[id];
   },


### PR DESCRIPTION
This will watch for changes in the mbtiles and hot-reload it.
To keep the implementation simple, the whole renderer is restarted.
This will create a small downtime.

It is very important to replace files atomically.

I tried to test all possible edge-cases, but we (geOps) don't use it in production yet. More testing would be much appreciated.