### PR TITLE
Update Maplibre-Native to v5.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   ci:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repository ✨ (non-dependabot)
         if: ${{ github.actor != 'dependabot[bot]' }}

--- a/.github/workflows/ct.yml
+++ b/.github/workflows/ct.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   ct:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repository ✨ (non-dependabot)
         if: ${{ github.actor != 'dependabot[bot]' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   release:
     name: 'Build, Test, Publish'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repository ✨
         uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal AS builder
+FROM ubuntu:jammy AS builder
 
 ENV NODE_ENV="production"
 
@@ -15,7 +15,7 @@ RUN set -ex; \
       libglfw3-dev \
       libuv1-dev \
       libjpeg-turbo8 \
-      libicu66 \
+      libicu70 \
       libcairo2-dev \
       libpango1.0-dev \
       libjpeg-dev \
@@ -58,7 +58,7 @@ RUN npm config set maxsockets 1; \
     npm ci --omit=dev; \
     chown -R root:root /usr/src/app;
 
-FROM ubuntu:focal AS final
+FROM ubuntu:jammy AS final
 
 ENV \
     NODE_ENV="production" \
@@ -78,7 +78,7 @@ RUN set -ex; \
       libglfw3 \
       libuv1 \
       libjpeg-turbo8 \
-      libicu66 \
+      libicu70 \
       libcairo2 \
       libgif7 \
       libopengl0 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN mkdir -p /etc/apt/keyrings; \
     curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg; \
-    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list; \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list; \
     apt-get -qq update; \
     apt-get install -y nodejs; \
     npm i -g npm@latest; \
@@ -94,7 +94,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN mkdir -p /etc/apt/keyrings; \
     curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg; \
-    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list; \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list; \
     apt-get -qq update; \
     apt-get install -y nodejs; \
     npm i -g npm@latest; \

--- a/Dockerfile_light
+++ b/Dockerfile_light
@@ -1,4 +1,4 @@
-FROM ubuntu:focal
+FROM ubuntu:jammy
 
 ENV \
     NODE_ENV="production" \

--- a/Dockerfile_light
+++ b/Dockerfile_light
@@ -16,7 +16,7 @@ RUN set -ex; \
       gnupg; \
     mkdir -p /etc/apt/keyrings; \
     curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg; \
-    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list; \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list; \
     apt-get -qq update; \
     apt-get install -y nodejs; \
     npm i -g npm@latest; \

--- a/Dockerfile_test
+++ b/Dockerfile_test
@@ -2,7 +2,7 @@
 # Simply run "docker build -f Dockerfile_test ."
 # WARNING: sometimes it fails with a core dumped exception
 
-FROM ubuntu:focal
+FROM ubuntu:jammy
 
 ENV NODE_ENV="development"
 
@@ -19,7 +19,7 @@ RUN set -ex; \
       libglfw3-dev \
       libuv1-dev \
       libjpeg-turbo8 \
-      libicu66 \
+      libicu70 \
       libcairo2-dev \
       libpango1.0-dev \
       libjpeg-dev \

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -46,9 +46,9 @@ Install locally from source
 Native dependencies
 -------------------
 
-Ubuntu 20.04 (x64/arm64)
+Ubuntu 22.04 (x64/arm64)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
-- apt install build-essential pkg-config xvfb libglfw3-dev libuv1-dev libjpeg-turbo8 libicu66 libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev gir1.2-rsvg-2.0 librsvg2-2 librsvg2-common libcurl4-openssl-dev libpixman-1-dev libpixman-1-0
+- apt install build-essential pkg-config xvfb libglfw3-dev libuv1-dev libjpeg-turbo8 libicu70 libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev gir1.2-rsvg-2.0 librsvg2-2 librsvg2-common libcurl4-openssl-dev libpixman-1-dev libpixman-1-0
 
 MacOS 12 (x64/arm64)
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -21,11 +21,11 @@ npm is supported on the following platforms with `Native Dependencies <#id1>`_ i
 
 - Operating systems:
 
-  - Ubuntu 20.04 (x64/arm64)
+  - Ubuntu 22.04 (x64/arm64)
   - macOS 12 (x64/arm64)
   - Windows (x64)
 
-- Node.js 18
+- Node.js 18,20
   
 Install globally from npmjs.
 ------------------------------

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@mapbox/polyline": "^1.2.1",
         "@mapbox/sphericalmercator": "1.2.0",
         "@mapbox/vector-tile": "1.3.1",
-        "@maplibre/maplibre-gl-native": "5.2.0",
+        "@maplibre/maplibre-gl-native": "5.3.0-pre.0",
         "@maplibre/maplibre-gl-style-spec": "18.0.0",
         "@sindresorhus/fnv1a": "3.1.0",
         "advanced-pool": "0.3.3",
@@ -72,9 +72,9 @@
       }
     },
     "node_modules/@acalcutt/node-pre-gyp": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@acalcutt/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
-      "integrity": "sha512-aeT0m5l3TdO0Mzs0lVIN6Qq+RYGyUu8XoE46r/o2mpZ/ve5o9B/AQT12S1ACIrQGHf0BrGGSy9yhV9SUe7ogJw==",
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@acalcutt/node-pre-gyp/-/node-pre-gyp-1.0.14.tgz",
+      "integrity": "sha512-P+xIiJefMa2ylrqPDwCw1S4Xr6ULKvF5TqmbZKifPSzId9jiSgLoplKfTmoP/y3Mq2kWts/rZDX1N9wMaSl6ZA==",
       "dependencies": {
         "detect-libc": "^2.0.0",
         "https-proxy-agent": "^5.0.0",
@@ -1172,12 +1172,12 @@
       }
     },
     "node_modules/@maplibre/maplibre-gl-native": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-native/-/maplibre-gl-native-5.2.0.tgz",
-      "integrity": "sha512-9Y5oC4cc+PpeCdb4XfBv0o74AU4SKvZPCOjcWnj4g2P15TK3o3M0biSP3PTMx7vqIvvHEkWz/ybTXXCR7mrd2g==",
+      "version": "5.3.0-pre.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-native/-/maplibre-gl-native-5.3.0-pre.0.tgz",
+      "integrity": "sha512-/42pvgvtfccWfs9FfZHGKlgxc84I5slt4Xsm1f0N0synCqHmOCBikivg/TbAs74hDKbD87LBecJ8oMhmwfBOhQ==",
       "hasInstallScript": true,
       "dependencies": {
-        "@acalcutt/node-pre-gyp": "^1.0.11",
+        "@acalcutt/node-pre-gyp": "^1.0.14",
         "@acalcutt/node-pre-gyp-github": "1.4.8",
         "minimatch": "^7.2.0",
         "npm-run-all": "^4.0.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@mapbox/polyline": "^1.2.1",
         "@mapbox/sphericalmercator": "1.2.0",
         "@mapbox/vector-tile": "1.3.1",
-        "@maplibre/maplibre-gl-native": "5.3.0-pre.0",
+        "@maplibre/maplibre-gl-native": "5.3.0",
         "@maplibre/maplibre-gl-style-spec": "18.0.0",
         "@sindresorhus/fnv1a": "3.1.0",
         "advanced-pool": "0.3.3",
@@ -59,7 +59,7 @@
         "yaml-lint": "^1.7.0"
       },
       "engines": {
-        "node": ">=18.17.0 <19"
+        "node": ">=18.17.0 <21"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1172,9 +1172,9 @@
       }
     },
     "node_modules/@maplibre/maplibre-gl-native": {
-      "version": "5.3.0-pre.0",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-native/-/maplibre-gl-native-5.3.0-pre.0.tgz",
-      "integrity": "sha512-/42pvgvtfccWfs9FfZHGKlgxc84I5slt4Xsm1f0N0synCqHmOCBikivg/TbAs74hDKbD87LBecJ8oMhmwfBOhQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-native/-/maplibre-gl-native-5.3.0.tgz",
+      "integrity": "sha512-58/yM3Gzwt6HtBUiwRhCH4eomStBsQ3ZCww/3WFee6gsG1bJLz9Y5CCcJI7J5WtLDTJIppcYcx4rhfgBnAzXnw==",
       "hasInstallScript": true,
       "dependencies": {
         "@acalcutt/node-pre-gyp": "^1.0.14",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tileserver-gl",
-  "version": "4.7.0",
+  "version": "4.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tileserver-gl",
-      "version": "4.7.0",
+      "version": "4.8.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@mapbox/glyph-pbf-composite": "0.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "husky": "^8.0.3",
         "lint-staged": "^15.2.0",
         "mocha": "^10.2.0",
+        "node-addon-api": "^7",
         "prettier": "^3.2.1",
         "should": "^13.2.3",
         "supertest": "^6.3.3",
@@ -5977,9 +5978,10 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "node_modules/node-addon-api": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
-      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ=="
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.0.0.tgz",
+      "integrity": "sha512-vgbBJTS4m5/KkE16t5Ly0WW9hz46swAstv0hYYwMtbG7AznRhNyfLRe8HZAiWIpcHzoO7HxhLuBQj9rJ/Ho0ZA==",
+      "dev": true
     },
     "node_modules/node-fetch": {
       "version": "2.6.7",
@@ -7669,6 +7671,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/sqlite3/node_modules/node-addon-api": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ=="
     },
     "node_modules/ssri": {
       "version": "8.0.1",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   ],
   "license": "BSD-2-Clause",
   "engines": {
-    "node": ">=18.17.0 <19"
+    "node": ">=18.17.0 <21"
   },
   "repository": {
     "url": "git+https://github.com/maptiler/tileserver-gl.git",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "husky": "^8.0.3",
     "lint-staged": "^15.2.0",
     "mocha": "^10.2.0",
+    "node-addon-api": "^7",
     "prettier": "^3.2.1",
     "should": "^13.2.3",
     "supertest": "^6.3.3",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@mapbox/polyline": "^1.2.1",
     "@mapbox/sphericalmercator": "1.2.0",
     "@mapbox/vector-tile": "1.3.1",
-    "@maplibre/maplibre-gl-native": "5.3.0-pre.0",
+    "@maplibre/maplibre-gl-native": "5.3.0",
     "@maplibre/maplibre-gl-style-spec": "18.0.0",
     "@sindresorhus/fnv1a": "3.1.0",
     "advanced-pool": "0.3.3",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@mapbox/polyline": "^1.2.1",
     "@mapbox/sphericalmercator": "1.2.0",
     "@mapbox/vector-tile": "1.3.1",
-    "@maplibre/maplibre-gl-native": "5.2.0",
+    "@maplibre/maplibre-gl-native": "5.3.0-pre.0",
     "@maplibre/maplibre-gl-style-spec": "18.0.0",
     "@sindresorhus/fnv1a": "3.1.0",
     "advanced-pool": "0.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tileserver-gl",
-  "version": "4.7.0",
+  "version": "4.8.0",
   "description": "Map tile server for JSON GL styles - vector and server side generated raster tiles",
   "main": "src/main.js",
   "bin": "src/main.js",


### PR DESCRIPTION
I recently worked with the maplibre-native team to make a new node release, [node-v5.3.0](https://github.com/maplibre/maplibre-native/releases/tag/node-v5.3.0). This new maplibre-native adds node 20 support. It is also built on Ubuntu 22.04

For tileserver-gl, this means new OS requirements for linux. It also means we can move up to node 20.  The attached changes updates tileserver-gl docker to ubuntu:jammy (22.04) and node 20 . It also updates package.json and documentation to reflect the new requirements.

If anyone has a change to test this release, please let me know how it goes.
