### PR TITLE
Fix WMTS endpoint issues after 512px tile PR

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tileserver-gl",
-  "version": "4.9.0",
+  "version": "4.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tileserver-gl",
-      "version": "4.9.0",
+      "version": "4.9.1",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@mapbox/glyph-pbf-composite": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tileserver-gl",
-  "version": "4.9.0",
+  "version": "4.9.1",
   "description": "Map tile server for JSON GL styles - vector and server side generated raster tiles",
   "main": "src/main.js",
   "bin": "src/main.js",

--- a/public/templates/wmts.tmpl
+++ b/public/templates/wmts.tmpl
@@ -38,7 +38,7 @@
   <Contents>
     <Layer>
       <ows:Title>{{name}}-256</ows:Title>
-      <ows:Identifier>{{id}}</ows:Identifier>
+      <ows:Identifier>{{id}}-256</ows:Identifier>
       <ows:WGS84BoundingBox crs="urn:ogc:def:crs:OGC:2:84">
         <ows:LowerCorner>-180 -85.051128779807</ows:LowerCorner>
         <ows:UpperCorner>180 85.051128779807</ows:UpperCorner>
@@ -54,7 +54,7 @@
     </Layer>
     <Layer>
       <ows:Title>{{name}}-512</ows:Title>
-      <ows:Identifier>{{id}}</ows:Identifier>
+      <ows:Identifier>{{id}}-512</ows:Identifier>
       <ows:WGS84BoundingBox crs="urn:ogc:def:crs:OGC:2:84">
         <ows:LowerCorner>-180 -85.051128779807</ows:LowerCorner>
         <ows:UpperCorner>180 85.051128779807</ows:UpperCorner>
@@ -251,7 +251,7 @@
       <ows:Identifier>GoogleMapsCompatible_512</ows:Identifier>
       <ows:SupportedCRS>urn:ogc:def:crs:EPSG::3857</ows:SupportedCRS>
       <TileMatrix>
-        <ows:Identifier>0</ows:Identifier>
+        <ows:Identifier>1</ows:Identifier>
         <ScaleDenominator>279541132.0143589</ScaleDenominator>
         <TopLeftCorner>-20037508.34 20037508.34</TopLeftCorner>
         <TileWidth>512</TileWidth>
@@ -260,7 +260,7 @@
         <MatrixHeight>1</MatrixHeight>
       </TileMatrix>
       <TileMatrix>
-        <ows:Identifier>1</ows:Identifier>
+        <ows:Identifier>2</ows:Identifier>
         <ScaleDenominator>139770566.0071794</ScaleDenominator>
         <TopLeftCorner>-20037508.34 20037508.34</TopLeftCorner>
         <TileWidth>512</TileWidth>
@@ -269,7 +269,7 @@
         <MatrixHeight>2</MatrixHeight>
       </TileMatrix>
       <TileMatrix>
-        <ows:Identifier>2</ows:Identifier>
+        <ows:Identifier>3</ows:Identifier>
         <ScaleDenominator>69885283.00358972</ScaleDenominator>
         <TopLeftCorner>-20037508.34 20037508.34</TopLeftCorner>
         <TileWidth>512</TileWidth>
@@ -278,7 +278,7 @@
         <MatrixHeight>4</MatrixHeight>
       </TileMatrix>
       <TileMatrix>
-        <ows:Identifier>3</ows:Identifier>
+        <ows:Identifier>4</ows:Identifier>
         <ScaleDenominator>34942641.501795</ScaleDenominator>
         <TopLeftCorner>-20037508.34 20037508.34</TopLeftCorner>
         <TileWidth>512</TileWidth>
@@ -287,7 +287,7 @@
         <MatrixHeight>8</MatrixHeight>
       </TileMatrix>
       <TileMatrix>
-        <ows:Identifier>4</ows:Identifier>
+        <ows:Identifier>5</ows:Identifier>
         <ScaleDenominator>17471320.750897</ScaleDenominator>
         <TopLeftCorner>-20037508.34 20037508.34</TopLeftCorner>
         <TileWidth>512</TileWidth>
@@ -296,7 +296,7 @@
         <MatrixHeight>16</MatrixHeight>
       </TileMatrix>
       <TileMatrix>
-        <ows:Identifier>5</ows:Identifier>
+        <ows:Identifier>6</ows:Identifier>
         <ScaleDenominator>8735660.3754487</ScaleDenominator>
         <TopLeftCorner>-20037508.34 20037508.34</TopLeftCorner>
         <TileWidth>512</TileWidth>
@@ -305,7 +305,7 @@
         <MatrixHeight>32</MatrixHeight>
       </TileMatrix>
       <TileMatrix>
-        <ows:Identifier>6</ows:Identifier>
+        <ows:Identifier>7</ows:Identifier>
         <ScaleDenominator>4367830.1877244</ScaleDenominator>
         <TopLeftCorner>-20037508.34 20037508.34</TopLeftCorner>
         <TileWidth>512</TileWidth>
@@ -314,7 +314,7 @@
         <MatrixHeight>64</MatrixHeight>
       </TileMatrix>
       <TileMatrix>
-        <ows:Identifier>7</ows:Identifier>
+        <ows:Identifier>8</ows:Identifier>
         <ScaleDenominator>2183915.0938622</ScaleDenominator>
         <TopLeftCorner>-20037508.34 20037508.34</TopLeftCorner>
         <TileWidth>512</TileWidth>
@@ -323,7 +323,7 @@
         <MatrixHeight>128</MatrixHeight>
       </TileMatrix>
       <TileMatrix>
-        <ows:Identifier>8</ows:Identifier>
+        <ows:Identifier>9</ows:Identifier>
         <ScaleDenominator>1091957.5469311</ScaleDenominator>
         <TopLeftCorner>-20037508.34 20037508.34</TopLeftCorner>
         <TileWidth>512</TileWidth>
@@ -332,7 +332,7 @@
         <MatrixHeight>256</MatrixHeight>
       </TileMatrix>
       <TileMatrix>
-        <ows:Identifier>9</ows:Identifier>
+        <ows:Identifier>10</ows:Identifier>
         <ScaleDenominator>545978.77346554</ScaleDenominator>
         <TopLeftCorner>-20037508.34 20037508.34</TopLeftCorner>
         <TileWidth>512</TileWidth>
@@ -341,7 +341,7 @@
         <MatrixHeight>512</MatrixHeight>
       </TileMatrix>
       <TileMatrix>
-        <ows:Identifier>10</ows:Identifier>
+        <ows:Identifier>11</ows:Identifier>
         <ScaleDenominator>272989.38673277</ScaleDenominator>
         <TopLeftCorner>-20037508.34 20037508.34</TopLeftCorner>
         <TileWidth>512</TileWidth>
@@ -350,7 +350,7 @@
         <MatrixHeight>1024</MatrixHeight>
       </TileMatrix>
       <TileMatrix>
-        <ows:Identifier>11</ows:Identifier>
+        <ows:Identifier>12</ows:Identifier>
         <ScaleDenominator>136494.69336639</ScaleDenominator>
         <TopLeftCorner>-20037508.34 20037508.34</TopLeftCorner>
         <TileWidth>512</TileWidth>
@@ -359,7 +359,7 @@
         <MatrixHeight>2048</MatrixHeight>
       </TileMatrix>
       <TileMatrix>
-        <ows:Identifier>12</ows:Identifier>
+        <ows:Identifier>13</ows:Identifier>
         <ScaleDenominator>68247.346683193</ScaleDenominator>
         <TopLeftCorner>-20037508.34 20037508.34</TopLeftCorner>
         <TileWidth>512</TileWidth>
@@ -368,7 +368,7 @@
         <MatrixHeight>4096</MatrixHeight>
       </TileMatrix>
       <TileMatrix>
-        <ows:Identifier>13</ows:Identifier>
+        <ows:Identifier>14</ows:Identifier>
         <ScaleDenominator>34123.673341597</ScaleDenominator>
         <TopLeftCorner>-20037508.34 20037508.34</TopLeftCorner>
         <TileWidth>512</TileWidth>
@@ -377,7 +377,7 @@
         <MatrixHeight>8192</MatrixHeight>
       </TileMatrix>
       <TileMatrix>
-        <ows:Identifier>14</ows:Identifier>
+        <ows:Identifier>15</ows:Identifier>
         <ScaleDenominator>17061.836670798</ScaleDenominator>
         <TopLeftCorner>-20037508.34 20037508.34</TopLeftCorner>
         <TileWidth>512</TileWidth>
@@ -386,7 +386,7 @@
         <MatrixHeight>16384</MatrixHeight>
       </TileMatrix>
       <TileMatrix>
-        <ows:Identifier>15</ows:Identifier>
+        <ows:Identifier>16</ows:Identifier>
         <ScaleDenominator>8530.9183353991</ScaleDenominator>
         <TopLeftCorner>-20037508.34 20037508.34</TopLeftCorner>
         <TileWidth>512</TileWidth>
@@ -395,7 +395,7 @@
         <MatrixHeight>32768</MatrixHeight>
       </TileMatrix>
       <TileMatrix>
-        <ows:Identifier>16</ows:Identifier>
+        <ows:Identifier>17</ows:Identifier>
         <ScaleDenominator>4265.4591676996</ScaleDenominator>
         <TopLeftCorner>-20037508.34 20037508.34</TopLeftCorner>
         <TileWidth>512</TileWidth>
@@ -404,7 +404,7 @@
         <MatrixHeight>65536</MatrixHeight>
       </TileMatrix>
       <TileMatrix>
-        <ows:Identifier>17</ows:Identifier>
+        <ows:Identifier>18</ows:Identifier>
         <ScaleDenominator>2132.7295838498</ScaleDenominator>
         <TopLeftCorner>-20037508.34 20037508.34</TopLeftCorner>
         <TileWidth>512</TileWidth>
@@ -413,7 +413,7 @@
         <MatrixHeight>131072</MatrixHeight>
       </TileMatrix>
       <TileMatrix>
-        <ows:Identifier>18</ows:Identifier>
+        <ows:Identifier>19</ows:Identifier>
         <ScaleDenominator>1066.364791924892</ScaleDenominator>
         <TopLeftCorner>-20037508.34 20037508.34</TopLeftCorner>
         <TileWidth>512</TileWidth>


### PR DESCRIPTION
I found I had missed an issue in wmts in https://github.com/maptiler/tileserver-gl/pull/1136

The two issues were the following
1.) Both layers had the same identifier. This seemed to cause the wrong one to be loaded when I tested with arcgis online

2.) 512px tiles were misaligned, and getting 404 'invalid center' errors. I think this was because it was requesting the wrong zoom level tiles. I fixed this by raising the identifier by 1 for all 512pm TileMatixes


Before the wmts enpoint looked like this
![image](https://github.com/maptiler/tileserver-gl/assets/3792408/3f4ce146-6fda-40e8-82b2-402f690ae22e)

But after these changes it looks correct, and I am able to search locations and get the correct place (where before i couldn't)
![image](https://github.com/maptiler/tileserver-gl/assets/3792408/2b71b03a-f134-448b-ab22-f6a61b75ee42)

