### PR TITLE
Fix 512px tiles so they work with maplibre-js raster 512 tilesize

### DIFF
--- a/public/templates/viewer.tmpl
+++ b/public/templates/viewer.tmpl
@@ -108,6 +108,7 @@
             for (tile_url in tile_urls) {
                 L.tileLayer(tile_urls[tile_url], {
                     tileSize: 512,
+                    zoomOffset: -1,
                     minZoom: tile_minzoom,
                     maxZoom: tile_maxzoom,
                     attribution: tile_attribution

--- a/public/templates/wmts.tmpl
+++ b/public/templates/wmts.tmpl
@@ -778,4 +778,8 @@
     </TileMatrixSet>
   </Contents>
   <ServiceMetadataURL xlink:href="{{baseUrl}}styles/{{id}}/wmts.xml"/>
+  <Attribution>
+    <Title>{{tileJSON.attribution}}</Title>
+    <OnlineResource xlink:type="simple" xlink:href="{{baseUrl}}styles/{{id}}/wmts.xml"/>
+  </Attribution>
 </Capabilities>

--- a/public/templates/wmts.tmpl
+++ b/public/templates/wmts.tmpl
@@ -778,8 +778,4 @@
     </TileMatrixSet>
   </Contents>
   <ServiceMetadataURL xlink:href="{{baseUrl}}styles/{{id}}/wmts.xml"/>
-  <Attribution>
-    <Title>{{tileJSON.attribution}}</Title>
-    <OnlineResource xlink:type="simple" xlink:href="{{baseUrl}}styles/{{id}}/wmts.xml"/>
-  </Attribution>
 </Capabilities>

--- a/public/templates/wmts.tmpl
+++ b/public/templates/wmts.tmpl
@@ -251,7 +251,7 @@
       <ows:Identifier>GoogleMapsCompatible_512</ows:Identifier>
       <ows:SupportedCRS>urn:ogc:def:crs:EPSG::3857</ows:SupportedCRS>
       <TileMatrix>
-        <ows:Identifier>1</ows:Identifier>
+        <ows:Identifier>0</ows:Identifier>
         <ScaleDenominator>279541132.0143589</ScaleDenominator>
         <TopLeftCorner>-20037508.34 20037508.34</TopLeftCorner>
         <TileWidth>512</TileWidth>
@@ -260,7 +260,7 @@
         <MatrixHeight>1</MatrixHeight>
       </TileMatrix>
       <TileMatrix>
-        <ows:Identifier>2</ows:Identifier>
+        <ows:Identifier>1</ows:Identifier>
         <ScaleDenominator>139770566.0071794</ScaleDenominator>
         <TopLeftCorner>-20037508.34 20037508.34</TopLeftCorner>
         <TileWidth>512</TileWidth>
@@ -269,7 +269,7 @@
         <MatrixHeight>2</MatrixHeight>
       </TileMatrix>
       <TileMatrix>
-        <ows:Identifier>3</ows:Identifier>
+        <ows:Identifier>2</ows:Identifier>
         <ScaleDenominator>69885283.00358972</ScaleDenominator>
         <TopLeftCorner>-20037508.34 20037508.34</TopLeftCorner>
         <TileWidth>512</TileWidth>
@@ -278,7 +278,7 @@
         <MatrixHeight>4</MatrixHeight>
       </TileMatrix>
       <TileMatrix>
-        <ows:Identifier>4</ows:Identifier>
+        <ows:Identifier>3</ows:Identifier>
         <ScaleDenominator>34942641.501795</ScaleDenominator>
         <TopLeftCorner>-20037508.34 20037508.34</TopLeftCorner>
         <TileWidth>512</TileWidth>
@@ -287,7 +287,7 @@
         <MatrixHeight>8</MatrixHeight>
       </TileMatrix>
       <TileMatrix>
-        <ows:Identifier>5</ows:Identifier>
+        <ows:Identifier>4</ows:Identifier>
         <ScaleDenominator>17471320.750897</ScaleDenominator>
         <TopLeftCorner>-20037508.34 20037508.34</TopLeftCorner>
         <TileWidth>512</TileWidth>
@@ -296,7 +296,7 @@
         <MatrixHeight>16</MatrixHeight>
       </TileMatrix>
       <TileMatrix>
-        <ows:Identifier>6</ows:Identifier>
+        <ows:Identifier>5</ows:Identifier>
         <ScaleDenominator>8735660.3754487</ScaleDenominator>
         <TopLeftCorner>-20037508.34 20037508.34</TopLeftCorner>
         <TileWidth>512</TileWidth>
@@ -305,7 +305,7 @@
         <MatrixHeight>32</MatrixHeight>
       </TileMatrix>
       <TileMatrix>
-        <ows:Identifier>7</ows:Identifier>
+        <ows:Identifier>6</ows:Identifier>
         <ScaleDenominator>4367830.1877244</ScaleDenominator>
         <TopLeftCorner>-20037508.34 20037508.34</TopLeftCorner>
         <TileWidth>512</TileWidth>
@@ -314,7 +314,7 @@
         <MatrixHeight>64</MatrixHeight>
       </TileMatrix>
       <TileMatrix>
-        <ows:Identifier>8</ows:Identifier>
+        <ows:Identifier>7</ows:Identifier>
         <ScaleDenominator>2183915.0938622</ScaleDenominator>
         <TopLeftCorner>-20037508.34 20037508.34</TopLeftCorner>
         <TileWidth>512</TileWidth>
@@ -323,7 +323,7 @@
         <MatrixHeight>128</MatrixHeight>
       </TileMatrix>
       <TileMatrix>
-        <ows:Identifier>9</ows:Identifier>
+        <ows:Identifier>8</ows:Identifier>
         <ScaleDenominator>1091957.5469311</ScaleDenominator>
         <TopLeftCorner>-20037508.34 20037508.34</TopLeftCorner>
         <TileWidth>512</TileWidth>
@@ -332,7 +332,7 @@
         <MatrixHeight>256</MatrixHeight>
       </TileMatrix>
       <TileMatrix>
-        <ows:Identifier>10</ows:Identifier>
+        <ows:Identifier>9</ows:Identifier>
         <ScaleDenominator>545978.77346554</ScaleDenominator>
         <TopLeftCorner>-20037508.34 20037508.34</TopLeftCorner>
         <TileWidth>512</TileWidth>
@@ -341,7 +341,7 @@
         <MatrixHeight>512</MatrixHeight>
       </TileMatrix>
       <TileMatrix>
-        <ows:Identifier>11</ows:Identifier>
+        <ows:Identifier>10</ows:Identifier>
         <ScaleDenominator>272989.38673277</ScaleDenominator>
         <TopLeftCorner>-20037508.34 20037508.34</TopLeftCorner>
         <TileWidth>512</TileWidth>
@@ -350,7 +350,7 @@
         <MatrixHeight>1024</MatrixHeight>
       </TileMatrix>
       <TileMatrix>
-        <ows:Identifier>12</ows:Identifier>
+        <ows:Identifier>11</ows:Identifier>
         <ScaleDenominator>136494.69336639</ScaleDenominator>
         <TopLeftCorner>-20037508.34 20037508.34</TopLeftCorner>
         <TileWidth>512</TileWidth>
@@ -359,7 +359,7 @@
         <MatrixHeight>2048</MatrixHeight>
       </TileMatrix>
       <TileMatrix>
-        <ows:Identifier>13</ows:Identifier>
+        <ows:Identifier>12</ows:Identifier>
         <ScaleDenominator>68247.346683193</ScaleDenominator>
         <TopLeftCorner>-20037508.34 20037508.34</TopLeftCorner>
         <TileWidth>512</TileWidth>
@@ -368,7 +368,7 @@
         <MatrixHeight>4096</MatrixHeight>
       </TileMatrix>
       <TileMatrix>
-        <ows:Identifier>14</ows:Identifier>
+        <ows:Identifier>13</ows:Identifier>
         <ScaleDenominator>34123.673341597</ScaleDenominator>
         <TopLeftCorner>-20037508.34 20037508.34</TopLeftCorner>
         <TileWidth>512</TileWidth>
@@ -377,7 +377,7 @@
         <MatrixHeight>8192</MatrixHeight>
       </TileMatrix>
       <TileMatrix>
-        <ows:Identifier>15</ows:Identifier>
+        <ows:Identifier>14</ows:Identifier>
         <ScaleDenominator>17061.836670798</ScaleDenominator>
         <TopLeftCorner>-20037508.34 20037508.34</TopLeftCorner>
         <TileWidth>512</TileWidth>
@@ -386,7 +386,7 @@
         <MatrixHeight>16384</MatrixHeight>
       </TileMatrix>
       <TileMatrix>
-        <ows:Identifier>16</ows:Identifier>
+        <ows:Identifier>15</ows:Identifier>
         <ScaleDenominator>8530.9183353991</ScaleDenominator>
         <TopLeftCorner>-20037508.34 20037508.34</TopLeftCorner>
         <TileWidth>512</TileWidth>
@@ -395,7 +395,7 @@
         <MatrixHeight>32768</MatrixHeight>
       </TileMatrix>
       <TileMatrix>
-        <ows:Identifier>17</ows:Identifier>
+        <ows:Identifier>16</ows:Identifier>
         <ScaleDenominator>4265.4591676996</ScaleDenominator>
         <TopLeftCorner>-20037508.34 20037508.34</TopLeftCorner>
         <TileWidth>512</TileWidth>
@@ -404,7 +404,7 @@
         <MatrixHeight>65536</MatrixHeight>
       </TileMatrix>
       <TileMatrix>
-        <ows:Identifier>18</ows:Identifier>
+        <ows:Identifier>17</ows:Identifier>
         <ScaleDenominator>2132.7295838498</ScaleDenominator>
         <TopLeftCorner>-20037508.34 20037508.34</TopLeftCorner>
         <TileWidth>512</TileWidth>
@@ -413,7 +413,7 @@
         <MatrixHeight>131072</MatrixHeight>
       </TileMatrix>
       <TileMatrix>
-        <ows:Identifier>19</ows:Identifier>
+        <ows:Identifier>18</ows:Identifier>
         <ScaleDenominator>1066.364791924892</ScaleDenominator>
         <TopLeftCorner>-20037508.34 20037508.34</TopLeftCorner>
         <TileWidth>512</TileWidth>

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -574,7 +574,7 @@ export const serve_rendered = {
           return res.status(404).send('Out of bounds');
         }
 
-        let tileCenter
+        let tileCenter;
         if (tileSize === 512) {
           tileCenter = mercator_512.ll([((x + 0.5) / (1 << z)) * (tileSize << z),((y + 0.5) / (1 << z)) * (tileSize << z)],z);
         } else {

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -49,7 +49,7 @@ const PATH_PATTERN =
 const httpTester = /^(http(s)?:)?\/\//;
 
 const mercator = new SphericalMercator();
-const mercator_512 = new SphericalMercator({size: 512});
+const mercator_512 = new SphericalMercator({ size: 512 });
 const getScale = (scale) => (scale || '@1x').slice(1, 2) | 0;
 
 mlgl.on('message', (e) => {
@@ -414,14 +414,13 @@ const respondImage = (
     pool = item.map.renderersStatic[scale];
   }
   pool.acquire((err, renderer) => {
-
     // For 512px tiles, use the actual maplibre-native zoom. For 256px tiles, use zoom - 1
-    let mlglZ
-     if (width === 512) {
-       mlglZ = Math.max(0, z);
-     } else {
-       mlglZ = Math.max(0, z - 1);
-     }
+    let mlglZ;
+    if (width === 512) {
+      mlglZ = Math.max(0, z);
+    } else {
+      mlglZ = Math.max(0, z - 1);
+    }
 
     const params = {
       zoom: mlglZ,
@@ -437,7 +436,7 @@ const respondImage = (
       params.width *= 2;
       params.height *= 2;
     }
-    // END HACK(Part 1) 
+    // END HACK(Part 1)
 
     if (z > 0 && tileMargin > 0) {
       params.width += tileMargin * 2;
@@ -462,7 +461,10 @@ const respondImage = (
 
       if (z > 0 && tileMargin > 0) {
         const y = mercator.px(params.center, z)[1];
-        const yoffset = Math.max(Math.min(0, y - 128 - tileMargin), y + 128 + tileMargin - Math.pow(2, z + 8));
+        const yoffset = Math.max(
+          Math.min(0, y - 128 - tileMargin),
+          y + 128 + tileMargin - Math.pow(2, z + 8),
+        );
         image.extract({
           left: tileMargin * scale,
           top: (tileMargin + yoffset) * scale,
@@ -472,7 +474,7 @@ const respondImage = (
       }
 
       // END HACK(Part 2) 256px tiles are a zoom level lower than maplibre-native default tiles. this hack allows tileserver-gl to support zoom 0 256px tiles, which would actually be zoom -1 in maplibre-native. Since zoom -1 isn't supported, a double sized zoom 0 tile is requested and resized here.
-      if ((z === 0 && width === 256)) {
+      if (z === 0 && width === 256) {
         image.resize(width * scale, height * scale);
       }
       // END HACK(Part 2)
@@ -576,9 +578,21 @@ export const serve_rendered = {
 
         let tileCenter;
         if (tileSize === 512) {
-          tileCenter = mercator_512.ll([((x + 0.5) / (1 << z)) * (tileSize << z),((y + 0.5) / (1 << z)) * (tileSize << z)],z);
+          tileCenter = mercator_512.ll(
+            [
+              ((x + 0.5) / (1 << z)) * (tileSize << z),
+              ((y + 0.5) / (1 << z)) * (tileSize << z),
+            ],
+            z,
+          );
         } else {
-          tileCenter = mercator.ll([((x + 0.5) / (1 << z)) * (tileSize << z),((y + 0.5) / (1 << z)) * (tileSize << z)],z);
+          tileCenter = mercator.ll(
+            [
+              ((x + 0.5) / (1 << z)) * (tileSize << z),
+              ((y + 0.5) / (1 << z)) * (tileSize << z),
+            ],
+            z,
+          );
         }
 
         // prettier-ignore

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -49,7 +49,6 @@ const PATH_PATTERN =
 const httpTester = /^(http(s)?:)?\/\//;
 
 const mercator = new SphericalMercator();
-const mercator_512 = new SphericalMercator({ size: 512 });
 const getScale = (scale) => (scale || '@1x').slice(1, 2) | 0;
 
 mlgl.on('message', (e) => {
@@ -576,24 +575,13 @@ export const serve_rendered = {
           return res.status(404).send('Out of bounds');
         }
 
-        let tileCenter;
-        if (tileSize === 512) {
-          tileCenter = mercator_512.ll(
+        let tileCenter = mercator.ll(
             [
-              ((x + 0.5) / (1 << z)) * (tileSize << z),
-              ((y + 0.5) / (1 << z)) * (tileSize << z),
+              ((x + 0.5) / (1 << z)) * (256 << z),
+              ((y + 0.5) / (1 << z)) * (256 << z),
             ],
             z,
-          );
-        } else {
-          tileCenter = mercator.ll(
-            [
-              ((x + 0.5) / (1 << z)) * (tileSize << z),
-              ((y + 0.5) / (1 << z)) * (tileSize << z),
-            ],
-            z,
-          );
-        }
+        );
 
         // prettier-ignore
         return respondImage(

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -461,7 +461,7 @@ const respondImage = (
       });
 
       if (z > 0 && tileMargin > 0) {
-        const y = mercator.px(params.center, z)[1]
+        const y = mercator.px(params.center, z)[1];
         const yoffset = Math.max(Math.min(0, y - 128 - tileMargin), y + 128 + tileMargin - Math.pow(2, z + 8));
         image.extract({
           left: tileMargin * scale,

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -48,7 +48,7 @@ const PATH_PATTERN =
   /^((fill|stroke|width)\:[^\|]+\|)*(enc:.+|-?\d+(\.\d*)?,-?\d+(\.\d*)?(\|-?\d+(\.\d*)?,-?\d+(\.\d*)?)+)/;
 const httpTester = /^(http(s)?:)?\/\//;
 
-const mercator_256 = new SphericalMercator();
+const mercator = new SphericalMercator();
 const mercator_512 = new SphericalMercator({size: 512});
 const getScale = (scale) => (scale || '@1x').slice(1, 2) | 0;
 
@@ -349,8 +349,8 @@ const calcZForBBox = (bbox, w, h, query) => {
 
   const padding = query.padding !== undefined ? parseFloat(query.padding) : 0.1;
 
-  const minCorner = mercator_256.px([bbox[0], bbox[3]], z);
-  const maxCorner = mercator_256.px([bbox[2], bbox[1]], z);
+  const minCorner = mercator.px([bbox[0], bbox[3]], z);
+  const maxCorner = mercator.px([bbox[2], bbox[1]], z);
   const w_ = w / (1 + 2 * padding);
   const h_ = h / (1 + 2 * padding);
 
@@ -453,7 +453,7 @@ const respondImage = (
       });
 
       if (z > 0 && tileMargin > 0) {
-        const y = mercator_256.px(params.center, z)[1]
+        const y = mercator.px(params.center, z)[1]
         const yoffset = Math.max(Math.min(0, y - 128 - tileMargin), y + 128 + tileMargin - Math.pow(2, z + 8));
         image.extract({
           left: tileMargin * scale,
@@ -570,7 +570,7 @@ export const serve_rendered = {
         if (tileSize === 512) {
           tileCenter = mercator_512.ll([((x + 0.5) / (1 << z)) * (tileSize << z),((y + 0.5) / (1 << z)) * (tileSize << z)],z);
         } else {
-          tileCenter = mercator_256.ll([((x + 0.5) / (1 << z)) * (tileSize << z),((y + 0.5) / (1 << z)) * (tileSize << z)],z);
+          tileCenter = mercator.ll([((x + 0.5) / (1 << z)) * (tileSize << z),((y + 0.5) / (1 << z)) * (tileSize << z)],z);
         }
 
         // prettier-ignore
@@ -616,7 +616,7 @@ export const serve_rendered = {
             }
 
             const transformer = raw
-              ? mercator_256.inverse.bind(mercator)
+              ? mercator.inverse.bind(mercator)
               : item.dataProjWGStoInternalWGS;
 
             if (transformer) {
@@ -663,7 +663,7 @@ export const serve_rendered = {
           let center = [(bbox[0] + bbox[2]) / 2, (bbox[1] + bbox[3]) / 2];
 
           const transformer = raw
-            ? mercator_256.inverse.bind(mercator)
+            ? mercator.inverse.bind(mercator)
             : item.dataProjWGStoInternalWGS;
 
           if (transformer) {
@@ -759,7 +759,7 @@ export const serve_rendered = {
             const format = req.params.format;
 
             const transformer = raw
-              ? mercator_256.inverse.bind(mercator)
+              ? mercator.inverse.bind(mercator)
               : item.dataProjWGStoInternalWGS;
 
             const paths = extractPathsFromQuery(req.query, transformer);
@@ -791,8 +791,8 @@ export const serve_rendered = {
               bbox[3] = Math.max(bbox[3], pair[1]);
             }
 
-            const bbox_ = mercator_256.convert(bbox, '900913');
-            const center = mercator_256.inverse([
+            const bbox_ = mercator.convert(bbox, '900913');
+            const center = mercator.inverse([
               (bbox_[0] + bbox_[2]) / 2,
               (bbox_[1] + bbox_[3]) / 2,
             ]);

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -453,15 +453,8 @@ const respondImage = (
       });
 
       if (z > 0 && tileMargin > 0) {
-         let y
-         let yoffset
-         if (width === 512) {
-           y = mercator_512.px(params.center, z)[1]
-           yoffset = Math.max(Math.min(0, y - 256 - tileMargin), y + 256 + tileMargin - Math.pow(2, z + 8));
-         } else {
-           y = mercator_256.px(params.center, z)[1]
-           yoffset = Math.max(Math.min(0, y - 128 - tileMargin), y + 128 + tileMargin - Math.pow(2, z + 8));
-         }
+        const y = mercator_256.px(params.center, z)[1]
+        const yoffset = Math.max(Math.min(0, y - 128 - tileMargin), y + 128 + tileMargin - Math.pow(2, z + 8));
         image.extract({
           left: tileMargin * scale,
           top: (tileMargin + yoffset) * scale,

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -381,6 +381,14 @@ const respondImage = (
   overlay = null,
   mode = 'tile',
 ) => {
+  if (
+    Math.abs(lon) > 180 ||
+    Math.abs(lat) > 85.06 ||
+    lon !== lon ||
+    lat !== lat
+  ) {
+    return res.status(400).send('Invalid center');
+  }
 
   if (
     Math.min(width, height) <= 0 ||

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -472,7 +472,7 @@ const respondImage = (
         });
       }
 
-      // END HACK(Part 2) 256px tiles are a zoom level lower than maplibre-native default tiles. this hack allows tileserver-gl to support zoom 0 256px tiles, which would actually be zoom -1 in maplibre-native. Since zoom -1 isn't supported, a double sized zoom 0 tile is requested and resized here.
+      // HACK(Part 2) 256px tiles are a zoom level lower than maplibre-native default tiles. this hack allows tileserver-gl to support zoom 0 256px tiles, which would actually be zoom -1 in maplibre-native. Since zoom -1 isn't supported, a double sized zoom 0 tile is requested and resized here.
       if (z === 0 && width === 256) {
         image.resize(width * scale, height * scale);
       }

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -575,7 +575,7 @@ export const serve_rendered = {
           return res.status(404).send('Out of bounds');
         }
 
-        let tileCenter = mercator.ll(
+        const tileCenter = mercator.ll(
             [
               ((x + 0.5) / (1 << z)) * (256 << z),
               ((y + 0.5) / (1 << z)) * (256 << z),

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -424,14 +424,14 @@ const respondImage = (
       height,
     };
 
-    // HACK(Part 1) to allow for zoom 0 256px images. (z - 1) used byt 256 tiles would be -1, which isn't support. Instead a double size image is requested from zoom 0 and it is later resized. 
+    // HACK(Part 1) 256px tiles are a zoom level lower than maplibre-native default tiles. this hack allows tileserver-gl to support zoom 0 256px tiles, which would actually be zoom -1 in maplibre-native. Since zoom -1 isn't supported, a double sized zoom 0 tile is requested and resized in Part 2.
     if (z === 0 && width === 256) {
       params.width *= 2;
       params.height *= 2;
     }
     // END HACK(Part 1) 
 
-    if (((z > 2 && width === 256) || (z > 1 && width === 512))  && tileMargin > 0) {
+    if (z > 0 && tileMargin > 0) {
       params.width += tileMargin * 2;
       params.height += tileMargin * 2;
     }
@@ -452,7 +452,7 @@ const respondImage = (
         },
       });
 
-      if (((z > 2 && width === 256) || (z > 1 && width === 512))  && tileMargin > 0) {
+      if (z > 0 && tileMargin > 0) {
          let y
          let yoffset
          if (width === 512) {
@@ -470,7 +470,7 @@ const respondImage = (
         });
       }
 
-      // HACK(Part 2) to allow for zoom 0 256px images. (z - 1) used byt 256 tiles would be -1, which isn't support. Instead a double size image is requested from zoom 0 and it is resized here. 
+      // END HACK(Part 2) 256px tiles are a zoom level lower than maplibre-native default tiles. this hack allows tileserver-gl to support zoom 0 256px tiles, which would actually be zoom -1 in maplibre-native. Since zoom -1 isn't supported, a double sized zoom 0 tile is requested and resized here.
       if ((z === 0 && width === 256)) {
         image.resize(width * scale, height * scale);
       }

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -576,11 +576,11 @@ export const serve_rendered = {
         }
 
         const tileCenter = mercator.ll(
-            [
-              ((x + 0.5) / (1 << z)) * (256 << z),
-              ((y + 0.5) / (1 << z)) * (256 << z),
-            ],
-            z,
+          [
+            ((x + 0.5) / (1 << z)) * (256 << z),
+            ((y + 0.5) / (1 << z)) * (256 << z),
+          ],
+          z,
         );
 
         // prettier-ignore

--- a/src/server.js
+++ b/src/server.js
@@ -558,6 +558,7 @@ function start(opts) {
   */
   serveTemplate('/styles/:id/wmts.xml', 'wmts', (req) => {
     const { id } = req.params;
+    const { tileJSON } = serving.rendered[id];
     const wmts = clone((serving.styles || {})[id]);
 
     if (!wmts) {
@@ -582,6 +583,7 @@ function start(opts) {
     return {
       ...wmts,
       id,
+      tileJSON,
       name: (serving.styles[id] || serving.rendered[id]).name,
       baseUrl,
     };

--- a/src/server.js
+++ b/src/server.js
@@ -558,7 +558,6 @@ function start(opts) {
   */
   serveTemplate('/styles/:id/wmts.xml', 'wmts', (req) => {
     const { id } = req.params;
-    const { tileJSON } = serving.rendered[id];
     const wmts = clone((serving.styles || {})[id]);
 
     if (!wmts) {
@@ -583,7 +582,6 @@ function start(opts) {
     return {
       ...wmts,
       id,
-      tileJSON,
       name: (serving.styles[id] || serving.rendered[id]).name,
       baseUrl,
     };


### PR DESCRIPTION
In testing I found the 512px tiles we just added didn't work when used in maplibre-gl-js as a raster layer with a 512 tileSize. This is because of a zoom level difference between maplibre and leaflet. After some research I found that to use mapbox 512px tiles they usually get used with the leaflet option `zoomOffset: -1`  to make it request the next zoom level down. However, In the current code we were already removing a zoom level for 256px pixels, so it didn't seem needed.  However I realized 512px tiles are supposed to be in the default maplibre-native zoom levels, not zoom - 1 like 256px tiles. Because of the zoom level difference maplibre-js was trying to grab images that didn't exist on the previous zoom level.

This PR reworks the code so 512px uses regular mapbox/maplibre zoom levels (not zoom -1 like the 256px need). It also reverts wmts changes in https://github.com/maptiler/tileserver-gl/pull/1149 since they are no longer needed after this change.