### PR TITLE
Fix incorrect TileSize in index.json and data.json data urls. Add TileSize option to index.json and rendered.json endpoints for rendered urls.

### DIFF
--- a/docs/endpoints.rst
+++ b/docs/endpoints.rst
@@ -102,7 +102,9 @@ Source data
 
 TileJSON arrays
 ===============
-Array of all TileJSONs is at ``/index.json`` (``/rendered.json``; ``/data.json``)
+Array of all TileJSONs is at ``[/{tileSize}]/index.json`` (``[/{tileSize}]/rendered.json``; ``/data.json``)
+
+  * The optional tile size ``/{tileSize}`` (ex. ``/256``, ``/512``). if omitted, tileSize defaults to 256.
 
 List of available fonts
 =======================

--- a/src/server.js
+++ b/src/server.js
@@ -354,14 +354,12 @@ function start(opts) {
     res.send(result);
   });
 
-  const addTileJSONs = (arr, req, type) => {
+  const addTileJSONs = (arr, req, type, tileSize) => {
     for (const id of Object.keys(serving[type])) {
       const info = clone(serving[type][id].tileJSON);
       let path = '';
-      let tileSize = undefined;
       if (type === 'rendered') {
         path = `styles/${id}`;
-        tileSize = 512;
       } else {
         path = `${type}/${id}`;
       }
@@ -381,14 +379,16 @@ function start(opts) {
     return arr;
   };
 
-  app.get('/rendered.json', (req, res, next) => {
-    res.send(addTileJSONs([], req, 'rendered'));
+  app.get('/(:tileSize(256|512)/)?rendered.json', (req, res, next) => {
+    const tileSize = parseInt(req.params.tileSize, 10) || 256;
+    res.send(addTileJSONs([], req, 'rendered', tileSize));
   });
   app.get('/data.json', (req, res, next) => {
-    res.send(addTileJSONs([], req, 'data'));
+    res.send(addTileJSONs([], req, 'data', undefined));
   });
-  app.get('/index.json', (req, res, next) => {
-    res.send(addTileJSONs(addTileJSONs([], req, 'rendered'), req, 'data'));
+  app.get('/(:tileSize(256|512)/)?index.json', (req, res, next) => {
+    const tileSize = parseInt(req.params.tileSize, 10) || 256;
+    res.send(addTileJSONs(addTileJSONs([], req, 'rendered', tileSize), req, 'data', undefined));
   });
 
   // ------------------------------------

--- a/src/server.js
+++ b/src/server.js
@@ -388,7 +388,14 @@ function start(opts) {
   });
   app.get('/(:tileSize(256|512)/)?index.json', (req, res, next) => {
     const tileSize = parseInt(req.params.tileSize, 10) || 256;
-    res.send(addTileJSONs(addTileJSONs([], req, 'rendered', tileSize), req, 'data', undefined));
+    res.send(
+      addTileJSONs(
+        addTileJSONs([], req, 'rendered', tileSize),
+        req,
+        'data',
+        undefined,
+      ),
+    );
   });
 
   // ------------------------------------

--- a/src/server.js
+++ b/src/server.js
@@ -356,11 +356,12 @@ function start(opts) {
 
   const addTileJSONs = (arr, req, type) => {
     for (const id of Object.keys(serving[type])) {
-      const tileSize = 256;
       const info = clone(serving[type][id].tileJSON);
       let path = '';
+      let tileSize = undefined;
       if (type === 'rendered') {
         path = `styles/${id}`;
+        tileSize = 512;
       } else {
         path = `${type}/${id}`;
       }


### PR DESCRIPTION
https://github.com/maptiler/tileserver-gl/issues/1159 pointed out a bug where the index.json data enpoints were specifying a tile size. Data endpoints do not support TileSize in the url, so this was incorrect.

This PR makes several changes to fix and improve this.
1.) Data endpoints no longer include the TileSize
2.) I have updated the index.json and rendered.json to accept TileSize in the urls
3.) Fixed the url in data.json. Note that data.json does not support TileSize  in the url

With the change in this PR, the endpoints would now look like this

```
http://localhost:8080/index.json (256px rendered tile url with fixed data url)
http://localhost:8080/256/index.json (256px rendered tile url with fixed data url)
http://localhost:8080/512/index.json (512px rendered tile url with fixed data url)

http://localhost:8080/rendered.json (256px rendered tile url with fixed data url)
http://localhost:8080/256/rendered.json (256px rendered tile url with fixed data url)
http://localhost:8080/512/rendered.json (512px rendered tile url with fixed data url)

http://localhost:8080/data.json (fixed data url)
```