### PR TITLE
Fix exception in pmtiles format when GeoJSON is requested

### DIFF
--- a/src/serve_data.js
+++ b/src/serve_data.js
@@ -69,12 +69,6 @@ export const serve_data = {
               headers['Content-Type'] = 'application/x-protobuf';
             } else if (format === 'geojson') {
               headers['Content-Type'] = 'application/json';
-
-              if (isGzipped) {
-                data = zlib.unzipSync(data);
-                isGzipped = false;
-              }
-
               const tile = new VectorTile(new Pbf(data));
               const geojson = {
                 type: 'FeatureCollection',


### PR DESCRIPTION
Fixes exception when format `pmtiles` is used and `GeoJSON` is requested. Here the variable `isGzipped` is always undefined and the check is redundant because the data is already unzipped. See #1187.