### PR TITLE
Add support for multi-sprites in styles

### DIFF
--- a/docs/endpoints.rst
+++ b/docs/endpoints.rst
@@ -8,7 +8,7 @@ Styles
 ======
 * Styles are served at ``/styles/{id}/style.json`` (+ array at ``/styles.json``)
 
-  * Sprites at ``/styles/{id}/sprite[@2x].{format}``
+  * Sprites at ``/styles/{id}/sprite[/name][@2x].{format}``
   * Fonts at ``/fonts/{fontstack}/{start}-{end}.pbf``
 
 Rendered tiles

--- a/docs/endpoints.rst
+++ b/docs/endpoints.rst
@@ -8,7 +8,7 @@ Styles
 ======
 * Styles are served at ``/styles/{id}/style.json`` (+ array at ``/styles.json``)
 
-  * Sprites at ``/styles/{id}/sprite[/name][@2x].{format}``
+  * Sprites at ``/styles/{id}/sprite[/spriteID][@2x].{format}``
   * Fonts at ``/fonts/{fontstack}/{start}-{end}.pbf``
 
 Rendered tiles

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -1046,27 +1046,11 @@ export const serve_rendered = {
     }
 
     if (styleJSON.sprite) {
-      if (Array.isArray(styleJSON.sprite)) {
-        styleJSON.sprite.forEach((spriteItem) => {
-          if (!httpTester.test(spriteItem.url)) {
-            spriteItem.url =
-              'sprites://' +
-              spriteItem.url
-                .replace('{style}', path.basename(styleFile, '.json'))
-                .replace(
-                  '{styleJsonFolder}',
-                  path.relative(
-                    options.paths.sprites,
-                    path.dirname(styleJSONPath),
-                  ),
-                );
-          }
-        });
-      } else {
-        if (!httpTester.test(styleJSON.sprite)) {
-          styleJSON.sprite =
+      styleJSON.sprite.forEach((spriteItem) => {
+        if (!httpTester.test(spriteItem.url)) {
+          spriteItem.url =
             'sprites://' +
-            styleJSON.sprite
+            spriteItem.url
               .replace('{style}', path.basename(styleFile, '.json'))
               .replace(
                 '{styleJsonFolder}',
@@ -1076,7 +1060,7 @@ export const serve_rendered = {
                 ),
               );
         }
-      }
+      });
     }
 
     if (styleJSON.glyphs && !httpTester.test(styleJSON.glyphs)) {

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -1045,16 +1045,34 @@ export const serve_rendered = {
       return false;
     }
 
-    if (styleJSON.sprite && !httpTester.test(styleJSON.sprite)) {
-      styleJSON.sprite =
-        'sprites://' +
-        styleJSON.sprite
-          .replace('{style}', path.basename(styleFile, '.json'))
-          .replace(
-            '{styleJsonFolder}',
-            path.relative(options.paths.sprites, path.dirname(styleJSONPath)),
-          );
+    if (styleJSON.sprite) {
+      if (Array.isArray(styleJSON.sprite)) {
+        styleJSON.sprite.forEach((spriteItem) => {
+          if (!httpTester.test(spriteItem.url)) {
+            spriteItem.url =
+            'sprites://' +
+            spriteItem.url
+              .replace('{style}', path.basename(styleFile, '.json'))
+              .replace(
+                '{styleJsonFolder}',
+                path.relative(options.paths.sprites, path.dirname(styleJSONPath)),
+              );
+          }
+        });
+      } else {
+        if (!httpTester.test(styleJSON.sprite)) {
+          styleJSON.sprite =
+          'sprites://' +
+          styleJSON.sprite
+            .replace('{style}', path.basename(styleFile, '.json'))
+            .replace(
+              '{styleJsonFolder}',
+              path.relative(options.paths.sprites, path.dirname(styleJSONPath)),
+            );
+        }
+      }
     }
+
     if (styleJSON.glyphs && !httpTester.test(styleJSON.glyphs)) {
       styleJSON.glyphs = `fonts://${styleJSON.glyphs}`;
     }

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -46,7 +46,7 @@ import { renderOverlay, renderWatermark, renderAttribution } from './render.js';
 const FLOAT_PATTERN = '[+-]?(?:\\d+|\\d+.?\\d+)';
 const PATH_PATTERN =
   /^((fill|stroke|width)\:[^\|]+\|)*(enc:.+|-?\d+(\.\d*)?,-?\d+(\.\d*)?(\|-?\d+(\.\d*)?,-?\d+(\.\d*)?)+)/;
-const httpTester = /^(http(s)?:)?\/\//;
+const httpTester = /^https?:\/\//i;
 
 const mercator = new SphericalMercator();
 const getScale = (scale) => (scale || '@1x').slice(1, 2) | 0;

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -1046,6 +1046,9 @@ export const serve_rendered = {
     }
 
     if (styleJSON.sprite) {
+      if (!Array.isArray(styleJSON.sprite)) {
+        styleJSON.sprite = [{ id: 'default', url: styleJSON.sprite }];
+      }
       styleJSON.sprite.forEach((spriteItem) => {
         if (!httpTester.test(spriteItem.url)) {
           spriteItem.url =

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -1050,25 +1050,31 @@ export const serve_rendered = {
         styleJSON.sprite.forEach((spriteItem) => {
           if (!httpTester.test(spriteItem.url)) {
             spriteItem.url =
-            'sprites://' +
-            spriteItem.url
-              .replace('{style}', path.basename(styleFile, '.json'))
-              .replace(
-                '{styleJsonFolder}',
-                path.relative(options.paths.sprites, path.dirname(styleJSONPath)),
-              );
+              'sprites://' +
+              spriteItem.url
+                .replace('{style}', path.basename(styleFile, '.json'))
+                .replace(
+                  '{styleJsonFolder}',
+                  path.relative(
+                    options.paths.sprites,
+                    path.dirname(styleJSONPath),
+                  ),
+                );
           }
         });
       } else {
         if (!httpTester.test(styleJSON.sprite)) {
           styleJSON.sprite =
-          'sprites://' +
-          styleJSON.sprite
-            .replace('{style}', path.basename(styleFile, '.json'))
-            .replace(
-              '{styleJsonFolder}',
-              path.relative(options.paths.sprites, path.dirname(styleJSONPath)),
-            );
+            'sprites://' +
+            styleJSON.sprite
+              .replace('{style}', path.basename(styleFile, '.json'))
+              .replace(
+                '{styleJsonFolder}',
+                path.relative(
+                  options.paths.sprites,
+                  path.dirname(styleJSONPath),
+                ),
+              );
         }
       }
     }

--- a/src/serve_style.js
+++ b/src/serve_style.js
@@ -7,43 +7,11 @@ import clone from 'clone';
 import express from 'express';
 import { validateStyleMin } from '@maplibre/maplibre-gl-style-spec';
 
-import { getPublicUrl } from './utils.js';
+import { fixUrl, allowedOptions } from './utils.js';
 
 const httpTester = /^https?:\/\//i;
-const allowedSpriteScales = allowedOptions(['', '@2x', '@3x'], '');
+const allowedSpriteScales = allowedOptions(['', '@2x', '@3x']);
 const allowedSpriteFormats = allowedOptions(['png', 'json']);
-
-/**
- *
- * @param opts
- * @param root0
- * @param root0.defaultValue
- */
-function allowedOptions(opts, { defaultValue } = {}) {
-  const values = Object.fromEntries(opts.map((key) => [key, key]));
-  return (value) => values[value] || defaultValue;
-}
-
-/**
- *
- * @param req
- * @param url
- * @param publicUrl
- */
-function fixUrl(req, url, publicUrl) {
-  if (!url || typeof url !== 'string' || url.indexOf('local://') !== 0) {
-    return url;
-  }
-  const queryParams = [];
-  if (req.query.key) {
-    queryParams.unshift(`key=${encodeURIComponent(req.query.key)}`);
-  }
-  let query = '';
-  if (queryParams.length) {
-    query = `?${queryParams.join('&')}`;
-  }
-  return url.replace('local://', getPublicUrl(publicUrl, req)) + query;
-}
 
 export const serve_style = {
   init: (options, repo) => {

--- a/src/serve_style.js
+++ b/src/serve_style.js
@@ -85,24 +85,34 @@ export const serve_style = {
             spriteScale = as;
           }
         }
-
-        const filename = `${spritePath + spriteScale}.${format}`;
-        if (format !== 'png' && format !== 'json') {
+        if (!spriteScale) {
           return res.sendStatus(400);
-        } else {
-          // eslint-disable-next-line security/detect-non-literal-fs-filename
-          return fs.readFile(filename, (err, data) => {
-            if (err) {
-              console.log('Sprite load error:', filename);
-              return res.sendStatus(404);
-            } else {
-              if (format === 'json')
-                res.header('Content-type', 'application/json');
-              if (format === 'png') res.header('Content-type', 'image/png');
-              return res.send(data);
-            }
-          });
         }
+
+        let spriteFormat;
+        const allowedFormats = ['png', 'json']
+        for (const af of allowedFormats) {
+          if (af === format) {
+            spriteFormat = af;
+          }
+        }
+        if (!spriteFormat) {
+          return res.sendStatus(400);
+        }
+
+        const filename = `${spritePath + spriteScale}.${spriteFormat}`;
+        // eslint-disable-next-line security/detect-non-literal-fs-filename
+        return fs.readFile(filename, (err, data) => {
+          if (err) {
+            console.log('Sprite load error:', filename);
+            return res.sendStatus(404);
+          } else {
+            if (format === 'json')
+              res.header('Content-type', 'application/json');
+            if (format === 'png') res.header('Content-type', 'image/png');
+            return res.send(data);
+          }
+        });
       },
     );
 

--- a/src/serve_style.js
+++ b/src/serve_style.js
@@ -60,7 +60,7 @@ export const serve_style = {
       '/:id/sprite(/:name)?:scale(@[23]x)?.:format([\\w]+)',
       (req, res, next) => {
         const name = req.params.name || 'sprite';
-        const scale = req.params.scale || '';
+        const scale = req.params.scale.replace(/[^@23x]/g, '') || '';
         const format = req.params.format;
         const item = repo[req.params.id];
 
@@ -81,9 +81,7 @@ export const serve_style = {
 
         const filename = `${spritePath + scale}.${format}`;
         if (format !== 'png' && format !== 'json') {
-          return res
-            .sendStatus(400)
-            .send('Invalid format. Please use png or json.');
+          return res.sendStatus(400);
         } else {
           // eslint-disable-next-line security/detect-non-literal-fs-filename
           return fs.readFile(filename, (err, data) => {

--- a/src/serve_style.js
+++ b/src/serve_style.js
@@ -79,7 +79,7 @@ export const serve_style = {
         }
 
         let spriteScale;
-        const allowedScales = ['', '@2x', '@3x']
+        const allowedScales = ['', '@2x', '@3x'];
         for (const as of allowedScales) {
           if (as === scale) {
             spriteScale = as;
@@ -90,7 +90,7 @@ export const serve_style = {
         }
 
         let spriteFormat;
-        const allowedFormats = ['png', 'json']
+        const allowedFormats = ['png', 'json'];
         for (const af of allowedFormats) {
           if (af === format) {
             spriteFormat = af;

--- a/src/serve_style.js
+++ b/src/serve_style.js
@@ -160,7 +160,7 @@ export const serve_style = {
     }
 
     let spritePaths = [];
-    if (styleJSON.sprite && styleJSON.sprite) {
+    if (styleJSON.sprite) {
       if (Array.isArray(styleJSON.sprite)) {
         styleJSON.sprite.forEach((spriteItem) => {
           if (!httpTester.test(spriteItem.url)) {

--- a/src/serve_style.js
+++ b/src/serve_style.js
@@ -60,7 +60,11 @@ export const serve_style = {
       '/:id/sprite(/:name)?:scale(@[23]x)?.:format([\\w]+)',
       (req, res, next) => {
         const name = req.params.name || 'sprite';
-        const scale = req.params.scale.replace(/[^@23x]/g, '') || '';
+        const scale =
+          req.params.scale === '@2x' || req.params.scale === '@3x'
+            ? req.params.scale
+            : '';
+
         const format = req.params.format;
         const item = repo[req.params.id];
 

--- a/src/serve_style.js
+++ b/src/serve_style.js
@@ -13,11 +13,23 @@ const httpTester = /^https?:\/\//i;
 const allowedSpriteScales = allowedOptions(['', '@2x', '@3x'], '');
 const allowedSpriteFormats = allowedOptions(['png', 'json']);
 
+/**
+ *
+ * @param opts
+ * @param root0
+ * @param root0.defaultValue
+ */
 function allowedOptions(opts, { defaultValue } = {}) {
-  const values = Object.fromEntries(opts.map(key => [key, key]));
+  const values = Object.fromEntries(opts.map((key) => [key, key]));
   return (value) => values[value] || defaultValue;
 }
 
+/**
+ *
+ * @param req
+ * @param url
+ * @param publicUrl
+ */
 function fixUrl(req, url, publicUrl) {
   if (!url || typeof url !== 'string' || url.indexOf('local://') !== 0) {
     return url;
@@ -31,7 +43,7 @@ function fixUrl(req, url, publicUrl) {
     query = `?${queryParams.join('&')}`;
   }
   return url.replace('local://', getPublicUrl(publicUrl, req)) + query;
-};
+}
 
 export const serve_style = {
   init: (options, repo) => {
@@ -68,7 +80,9 @@ export const serve_style = {
 
         if (format) {
           const item = repo[id];
-          const sprite = item.spritePaths.find(sprite => sprite.id === spriteID);
+          const sprite = item.spritePaths.find(
+            (sprite) => sprite.id === spriteID,
+          );
           if (sprite) {
             const filename = `${sprite.path + scale}.${format}`;
             return fs.readFile(filename, (err, data) => {
@@ -159,7 +173,7 @@ export const serve_style = {
     let spritePaths = [];
     if (styleJSON.sprite) {
       if (!Array.isArray(styleJSON.sprite)) {
-        styleJSON.sprite = [{id: 'default', url: styleJSON.sprite }]; 
+        styleJSON.sprite = [{ id: 'default', url: styleJSON.sprite }];
       }
 
       for (let spriteItem of styleJSON.sprite) {

--- a/src/serve_style.js
+++ b/src/serve_style.js
@@ -63,9 +63,10 @@ export const serve_style = {
         const scale = req.params.scale || '';
         const format = req.params.format;
         const item = repo[req.params.id];
+        console.log(scale);
 
         let spritePath;
-        if (item && !item.spritePaths) {
+        if (item && item.spritePaths) {
           for (const sprite of item.spritePaths) {
             if (sprite.name === name) {
               spritePath = sprite.path;
@@ -85,9 +86,6 @@ export const serve_style = {
             spriteScale = as;
           }
         }
-        if (!spriteScale) {
-          return res.sendStatus(400);
-        }
 
         let spriteFormat;
         const allowedFormats = ['png', 'json'];
@@ -96,23 +94,25 @@ export const serve_style = {
             spriteFormat = af;
           }
         }
-        if (!spriteFormat) {
+
+        if (spriteFormat) {
+          const filename = `${spritePath + spriteScale}.${spriteFormat}`;
+          console.log(filename);
+          // eslint-disable-next-line security/detect-non-literal-fs-filename
+          return fs.readFile(filename, (err, data) => {
+            if (err) {
+              console.log('Sprite load error:', filename);
+              return res.sendStatus(404);
+            } else {
+              if (format === 'json')
+                res.header('Content-type', 'application/json');
+              if (format === 'png') res.header('Content-type', 'image/png');
+              return res.send(data);
+            }
+          });
+        } else {
           return res.sendStatus(400);
         }
-
-        const filename = `${spritePath + spriteScale}.${spriteFormat}`;
-        // eslint-disable-next-line security/detect-non-literal-fs-filename
-        return fs.readFile(filename, (err, data) => {
-          if (err) {
-            console.log('Sprite load error:', filename);
-            return res.sendStatus(404);
-          } else {
-            if (format === 'json')
-              res.header('Content-type', 'application/json');
-            if (format === 'png') res.header('Content-type', 'image/png');
-            return res.send(data);
-          }
-        });
       },
     );
 

--- a/src/serve_style.js
+++ b/src/serve_style.js
@@ -56,8 +56,9 @@ export const serve_style = {
       return res.send(styleJSON_);
     });
 
-    app.get('/:id/sprite/:name:scale(@[23]x)?.:format([\\w]+)', (req, res, next) => {
+    app.get('/:id/sprite(/:name)?:scale(@[23]x)?.:format([\\w]+)', (req, res, next) => {
       const item = repo[req.params.id];
+      const spriteName = req.params.name || 'sprite';
 
       if (!item || !item.spritePaths) {
         return res.sendStatus(404);
@@ -65,7 +66,7 @@ export const serve_style = {
 
       let spritePath
       for (const sprite of item.spritePaths) {
-        if (sprite.name === req.params.name) {
+        if (sprite.name === spriteName) {
           spritePath = sprite.path;
         }
       }
@@ -154,13 +155,12 @@ export const serve_style = {
       }
     }
 
-    let spriteName
     let spritePaths = [];
     if (styleJSON.sprite && styleJSON.sprite) {
       if (Array.isArray(styleJSON.sprite)) {
         styleJSON.sprite.forEach((spriteItem) => {
           if (!httpTester.test(spriteItem.url)) {
-            spriteName = spriteItem.url.substring(spriteItem.url.lastIndexOf('/') + 1);
+            let spriteName = spriteItem.url.substring(spriteItem.url.lastIndexOf('/') + 1);
             let spritePath = path.join(
               options.paths.sprites,
               spriteItem.url
@@ -176,7 +176,6 @@ export const serve_style = {
         });
       } else {
         if (!httpTester.test(styleJSON.sprite)) {
-          spriteName = styleJSON.sprite.substring(styleJSON.sprite.lastIndexOf('/') + 1);
           let spritePath = path.join(
             options.paths.sprites,
             styleJSON.sprite
@@ -186,8 +185,8 @@ export const serve_style = {
                 path.relative(options.paths.sprites, path.dirname(styleFile))
               )
           );
-          styleJSON.sprite = `local://styles/${id}/sprite/` + spriteName;
-          spritePaths.push({id: 'default', name: spriteName, path: spritePath});
+          styleJSON.sprite = `local://styles/${id}/sprite`;
+          spritePaths.push({id: 'default', name: 'sprite', path: spritePath});
         }
       }
     }

--- a/src/serve_style.js
+++ b/src/serve_style.js
@@ -63,7 +63,6 @@ export const serve_style = {
         const scale = req.params.scale || '';
         const format = req.params.format;
         const item = repo[req.params.id];
-        console.log(scale);
 
         let spritePath;
         if (item && item.spritePaths) {
@@ -97,7 +96,6 @@ export const serve_style = {
 
         if (spriteFormat) {
           const filename = `${spritePath + spriteScale}.${spriteFormat}`;
-          console.log(filename);
           // eslint-disable-next-line security/detect-non-literal-fs-filename
           return fs.readFile(filename, (err, data) => {
             if (err) {

--- a/src/serve_style.js
+++ b/src/serve_style.js
@@ -57,9 +57,9 @@ export const serve_style = {
     });
 
     app.get(
-      '/:id/sprite(/:name)?:scale(@[23]x)?.:format([\\w]+)',
+      '/:id/sprite(/:spriteID)?:scale(@[23]x)?.:format([\\w]+)',
       (req, res, next) => {
-        const name = req.params.name || 'sprite';
+        const spriteID = req.params.spriteID || 'default';
         const scale = req.params.scale || '';
         const format = req.params.format;
         const item = repo[req.params.id];
@@ -67,7 +67,7 @@ export const serve_style = {
         let spritePath;
         if (item && item.spritePaths) {
           for (const sprite of item.spritePaths) {
-            if (sprite.name === name) {
+            if (sprite.id === spriteID) {
               spritePath = sprite.path;
             }
           }
@@ -96,7 +96,6 @@ export const serve_style = {
 
         if (spriteFormat) {
           const filename = `${spritePath + spriteScale}.${spriteFormat}`;
-          // eslint-disable-next-line security/detect-non-literal-fs-filename
           return fs.readFile(filename, (err, data) => {
             if (err) {
               console.log('Sprite load error:', filename);
@@ -184,9 +183,6 @@ export const serve_style = {
       if (Array.isArray(styleJSON.sprite)) {
         styleJSON.sprite.forEach((spriteItem) => {
           if (!httpTester.test(spriteItem.url)) {
-            let spriteName = spriteItem.url.substring(
-              spriteItem.url.lastIndexOf('/') + 1,
-            );
             let spritePath = path.join(
               options.paths.sprites,
               spriteItem.url
@@ -196,12 +192,8 @@ export const serve_style = {
                   path.relative(options.paths.sprites, path.dirname(styleFile)),
                 ),
             );
-            spriteItem.url = `local://styles/${id}/sprite/` + spriteName;
-            spritePaths.push({
-              id: spriteItem.id,
-              name: spriteName,
-              path: spritePath,
-            });
+            spriteItem.url = `local://styles/${id}/sprite/` + spriteItem.id;
+            spritePaths.push({ id: spriteItem.id, path: spritePath });
           }
         });
       } else {
@@ -216,7 +208,7 @@ export const serve_style = {
               ),
           );
           styleJSON.sprite = `local://styles/${id}/sprite`;
-          spritePaths.push({ id: 'default', name: 'sprite', path: spritePath });
+          spritePaths.push({ id: 'default', path: spritePath });
         }
       }
     }

--- a/src/serve_style.js
+++ b/src/serve_style.js
@@ -60,30 +60,33 @@ export const serve_style = {
       '/:id/sprite(/:name)?:scale(@[23]x)?.:format([\\w]+)',
       (req, res, next) => {
         const name = req.params.name || 'sprite';
-        const scale =
-          req.params.scale === '@2x' || req.params.scale === '@3x'
-            ? req.params.scale
-            : '';
-
+        const scale = req.params.scale || '';
         const format = req.params.format;
         const item = repo[req.params.id];
 
-        if (!item || !item.spritePaths) {
+        let spritePath;
+        if (item && !item.spritePaths) {
+          for (const sprite of item.spritePaths) {
+            if (sprite.name === name) {
+              spritePath = sprite.path;
+            }
+          }
+          if (!spritePath) {
+            return res.sendStatus(404);
+          }
+        } else {
           return res.sendStatus(404);
         }
 
-        let spritePath;
-        for (const sprite of item.spritePaths) {
-          if (sprite.name === name) {
-            spritePath = sprite.path;
+        let spriteScale;
+        const allowedScales = ['', '@2x', '@3x']
+        for (const as of allowedScales) {
+          if (as === scale) {
+            spriteScale = as;
           }
         }
 
-        if (!spritePath) {
-          return res.sendStatus(404);
-        }
-
-        const filename = `${spritePath + scale}.${format}`;
+        const filename = `${spritePath + spriteScale}.${format}`;
         if (format !== 'png' && format !== 'json') {
           return res.sendStatus(400);
         } else {

--- a/src/serve_style.js
+++ b/src/serve_style.js
@@ -56,39 +56,43 @@ export const serve_style = {
       return res.send(styleJSON_);
     });
 
-    app.get('/:id/sprite(/:name)?:scale(@[23]x)?.:format([\\w]+)', (req, res, next) => {
-      const item = repo[req.params.id];
-      const spriteName = req.params.name || 'sprite';
+    app.get(
+      '/:id/sprite(/:name)?:scale(@[23]x)?.:format([\\w]+)',
+      (req, res, next) => {
+        const item = repo[req.params.id];
+        const spriteName = req.params.name || 'sprite';
 
-      if (!item || !item.spritePaths) {
-        return res.sendStatus(404);
-      }
-
-      let spritePath
-      for (const sprite of item.spritePaths) {
-        if (sprite.name === spriteName) {
-          spritePath = sprite.path;
-        }
-      }
-
-      if (!spritePath) {
-        return res.sendStatus(404);
-      }
-
-      const scale = req.params.scale;
-      const format = req.params.format;
-      const filename = `${spritePath + (scale || '')}.${format}`;
-      return fs.readFile(filename, (err, data) => {
-        if (err) {
-          console.log('Sprite load error:', filename);
+        if (!item || !item.spritePaths) {
           return res.sendStatus(404);
-        } else {
-          if (format === 'json') res.header('Content-type', 'application/json');
-          if (format === 'png') res.header('Content-type', 'image/png');
-          return res.send(data);
         }
-      });
-    });
+
+        let spritePath;
+        for (const sprite of item.spritePaths) {
+          if (sprite.name === spriteName) {
+            spritePath = sprite.path;
+          }
+        }
+
+        if (!spritePath) {
+          return res.sendStatus(404);
+        }
+
+        const scale = req.params.scale;
+        const format = req.params.format;
+        const filename = `${spritePath + (scale || '')}.${format}`;
+        return fs.readFile(filename, (err, data) => {
+          if (err) {
+            console.log('Sprite load error:', filename);
+            return res.sendStatus(404);
+          } else {
+            if (format === 'json')
+              res.header('Content-type', 'application/json');
+            if (format === 'png') res.header('Content-type', 'image/png');
+            return res.send(data);
+          }
+        });
+      },
+    );
 
     return app;
   },
@@ -160,18 +164,24 @@ export const serve_style = {
       if (Array.isArray(styleJSON.sprite)) {
         styleJSON.sprite.forEach((spriteItem) => {
           if (!httpTester.test(spriteItem.url)) {
-            let spriteName = spriteItem.url.substring(spriteItem.url.lastIndexOf('/') + 1);
+            let spriteName = spriteItem.url.substring(
+              spriteItem.url.lastIndexOf('/') + 1,
+            );
             let spritePath = path.join(
               options.paths.sprites,
               spriteItem.url
                 .replace('{style}', path.basename(styleFile, '.json'))
                 .replace(
                   '{styleJsonFolder}',
-                  path.relative(options.paths.sprites, path.dirname(styleFile))
-                )
+                  path.relative(options.paths.sprites, path.dirname(styleFile)),
+                ),
             );
             spriteItem.url = `local://styles/${id}/sprite/` + spriteName;
-            spritePaths.push({id: spriteItem.id, name: spriteName, path: spritePath});
+            spritePaths.push({
+              id: spriteItem.id,
+              name: spriteName,
+              path: spritePath,
+            });
           }
         });
       } else {
@@ -182,11 +192,11 @@ export const serve_style = {
               .replace('{style}', path.basename(styleFile, '.json'))
               .replace(
                 '{styleJsonFolder}',
-                path.relative(options.paths.sprites, path.dirname(styleFile))
-              )
+                path.relative(options.paths.sprites, path.dirname(styleFile)),
+              ),
           );
           styleJSON.sprite = `local://styles/${id}/sprite`;
-          spritePaths.push({id: 'default', name: 'sprite', path: spritePath});
+          spritePaths.push({ id: 'default', name: 'sprite', path: spritePath });
         }
       }
     }

--- a/src/serve_style.js
+++ b/src/serve_style.js
@@ -49,13 +49,9 @@ export const serve_style = {
       }
       // mapbox-gl-js viewer cannot handle sprite urls with query
       if (styleJSON_.sprite) {
-        if (Array.isArray(styleJSON_.sprite)) {
-          styleJSON_.sprite.forEach((spriteItem) => {
-            spriteItem.url = fixUrl(req, spriteItem.url, item.publicUrl);
-          });
-        } else {
-          styleJSON_.sprite = fixUrl(req, styleJSON_.sprite, item.publicUrl);
-        }
+        styleJSON_.sprite.forEach((spriteItem) => {
+          spriteItem.url = fixUrl(req, spriteItem.url, item.publicUrl);
+        });
       }
       if (styleJSON_.glyphs) {
         styleJSON_.glyphs = fixUrl(req, styleJSON_.glyphs, item.publicUrl);

--- a/src/serve_style.js
+++ b/src/serve_style.js
@@ -56,7 +56,7 @@ export const serve_style = {
       return res.send(styleJSON_);
     });
 
-    app.get('/:id/:name:scale(@[23]x)?.:format([\\w]+)', (req, res, next) => {
+    app.get('/:id/sprite/:name:scale(@[23]x)?.:format([\\w]+)', (req, res, next) => {
       const item = repo[req.params.id];
 
       if (!item || !item.spritePaths) {
@@ -170,7 +170,7 @@ export const serve_style = {
                   path.relative(options.paths.sprites, path.dirname(styleFile))
                 )
             );
-            spriteItem.url = `local://styles/${id}/` + spriteName;
+            spriteItem.url = `local://styles/${id}/sprite/` + spriteName;
             spritePaths.push({id: spriteItem.id, name: spriteName, path: spritePath});
           }
         });
@@ -186,7 +186,7 @@ export const serve_style = {
                 path.relative(options.paths.sprites, path.dirname(styleFile))
               )
           );
-          styleJSON.sprite = `local://styles/${id}/` + spriteName;
+          styleJSON.sprite = `local://styles/${id}/sprite/` + spriteName;
           spritePaths.push({id: 'default', name: spriteName, path: spritePath});
         }
       }

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,6 +7,38 @@ import clone from 'clone';
 import glyphCompose from '@mapbox/glyph-pbf-composite';
 
 /**
+ * Restrict user input to an allowed set of options.
+ * @param opts
+ * @param root0
+ * @param root0.defaultValue
+ */
+export function allowedOptions(opts, { defaultValue } = {}) {
+  const values = Object.fromEntries(opts.map((key) => [key, key]));
+  return (value) => values[value] || defaultValue;
+}
+
+/**
+ * Replace local:// urls with public http(s):// urls
+ * @param req
+ * @param url
+ * @param publicUrl
+ */
+export function fixUrl(req, url, publicUrl) {
+  if (!url || typeof url !== 'string' || url.indexOf('local://') !== 0) {
+    return url;
+  }
+  const queryParams = [];
+  if (req.query.key) {
+    queryParams.unshift(`key=${encodeURIComponent(req.query.key)}`);
+  }
+  let query = '';
+  if (queryParams.length) {
+    query = `?${queryParams.join('&')}`;
+  }
+  return url.replace('local://', getPublicUrl(publicUrl, req)) + query;
+}
+
+/**
  * Generate new URL object
  * @param req
  * @params {object} req - Express request

--- a/test/style.js
+++ b/test/style.js
@@ -41,6 +41,13 @@ describe('Styles', function () {
     testIs('/styles/' + prefix + '/sprite.png', /image\/png/);
     testIs('/styles/' + prefix + '/sprite@2x.png', /image\/png/);
   });
+
+  describe('/styles/' + prefix + '/sprite/default[@2x].{format}', function () {
+    testIs('/styles/' + prefix + '/sprite/default.json', /application\/json/);
+    testIs('/styles/' + prefix + '/sprite/default@2x.json', /application\/json/);
+    testIs('/styles/' + prefix + '/sprite/default.png', /image\/png/);
+    testIs('/styles/' + prefix + '/sprite/default@2x.png', /image\/png/);
+  });
 });
 
 describe('Fonts', function () {

--- a/test/style.js
+++ b/test/style.js
@@ -44,7 +44,10 @@ describe('Styles', function () {
 
   describe('/styles/' + prefix + '/sprite/default[@2x].{format}', function () {
     testIs('/styles/' + prefix + '/sprite/default.json', /application\/json/);
-    testIs('/styles/' + prefix + '/sprite/default@2x.json', /application\/json/);
+    testIs(
+      '/styles/' + prefix + '/sprite/default@2x.json',
+      /application\/json/,
+    );
     testIs('/styles/' + prefix + '/sprite/default.png', /image\/png/);
     testIs('/styles/' + prefix + '/sprite/default@2x.png', /image\/png/);
   });


### PR DESCRIPTION
maplibre-gl-native node-v5.4.0 adds support for multi-sprites ( https://maplibre.org/maplibre-style-spec/sprite/#multiple-sprite-sources ).

This PR allows tileserver-gl to handle an array of local sprites, in a format like
```
  "sprite": [
    {
      "id": "colored",
      "url": "{styleJsonFolder}/colored_sprites"
    },
    {
      "id": "default",
      "url": "{styleJsonFolder}/sprite"
    }
  ],
```

you can also specify urls, like shown in the style spec
```
  "sprite": [
    {
      "id": "colored",
      "url": "https://tiles.wifidb.net/styles/WDB_GPSTRAILS/sprite/colored_sprites"
    },
    {
      "id": "default",
      "url": "https://tiles.wifidb.net/styles/WDB_GPSTRAILS/sprite"
    }
  ],
```

**Example**
I updated this ATV trail map to use two different sets of sprites, ['default' and 'colored'](https://github.com/maptiler/tileserver-gl/pull/1232#issue-2254686185). You can see the default icons and colored icons show as expected
https://tiles.wifidb.net/styles/WDB_GPSTRAILS/?raster#15/45.0491/-69.8739
![image](https://github.com/maptiler/tileserver-gl/assets/3792408/30779cba-e5e4-497d-8d11-885170275b36)

