### PR TITLE
feat: add support for X-Forwarded-Path in style urls

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -48,7 +48,7 @@ const getUrlObject = (req) => {
   const urlObject = new URL(`${req.protocol}://${req.headers.host}/`);
   // support overriding hostname by sending X-Forwarded-Host http header
   urlObject.hostname = req.hostname;
-  
+
   // support add url prefix by sending X-Forwarded-Path http header
   const xForwardedPath = req.get('X-Forwarded-Path');
   if (xForwardedPath) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -48,6 +48,12 @@ const getUrlObject = (req) => {
   const urlObject = new URL(`${req.protocol}://${req.headers.host}/`);
   // support overriding hostname by sending X-Forwarded-Host http header
   urlObject.hostname = req.hostname;
+  
+  // support add url prefix by sending X-Forwarded-Path http header
+  const xForwardedPath = req.get('X-Forwarded-Path');
+  if (xForwardedPath) {
+    urlObject.pathname = path.posix.join(xForwardedPath, urlObject.pathname);
+  }
   return urlObject;
 };
 


### PR DESCRIPTION
Handling the X-Forwarded-Path header, if provided, in case the tileserver is behind a reverse-proxy served under a subpath, e.g.: /tiles/

In PR #1197 already added support for tiles urls.
This PR add support for urls in style files