### PR TITLE
fix: avoid synchronous calls where possible

### DIFF
--- a/src/promises.js
+++ b/src/promises.js
@@ -1,0 +1,14 @@
+import util from 'node:util';
+import fsp from 'node:fs/promises';
+import zlib from 'zlib';
+
+export const gzipP = util.promisify(zlib.gzip);
+export const gunzipP = util.promisify(zlib.gunzip);
+export const existsP = async (path) => {
+  try {
+    await fsp.access(path); // Defaults to F_OK: indicating that the file is visible to the calling process
+    return true;
+  } catch (err) {
+    return false;
+  }
+};

--- a/src/serve_style.js
+++ b/src/serve_style.js
@@ -87,7 +87,7 @@ export const serve_style = {
 
     let styleFileData;
     try {
-      styleFileData = fs.readFileSync(styleFile);
+      styleFileData = fs.readFileSync(styleFile); // TODO: could be made async if this function was
     } catch (e) {
       console.log('Error reading style file');
       return false;

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,9 +2,10 @@
 
 import path from 'path';
 import fsPromises from 'fs/promises';
-import fs, { existsSync } from 'node:fs';
+import fs from 'node:fs';
 import clone from 'clone';
 import { combine } from '@jsse/pbfont';
+import { existsP } from './promises.js';
 
 /**
  * Restrict user input to an allowed set of options.
@@ -225,7 +226,7 @@ export const listFonts = async (fontPath) => {
     const stats = await fsPromises.stat(path.join(fontPath, file));
     if (
       stats.isDirectory() &&
-      existsSync(path.join(fontPath, file, '0-255.pbf'))
+      (await existsP(path.join(fontPath, file, '0-255.pbf')))
     ) {
       existingFonts[path.basename(file)] = true;
     }


### PR DESCRIPTION
These were a bunch of `*Sync` calls that were rather easy to convert to promisified ones, either via `util.promisify` or just `node:fs/promises`.

There's at least one more place I didn't touch, solely because it would have required refactoring all of `server.js::start` to be async.

There are other places left (out of scope of this PR) where e.g. callback async could be converted to promises, etc.