### PR TITLE
refactor: add promisified wrapper for MBTiles

### DIFF
--- a/src/mbtiles_wrapper.js
+++ b/src/mbtiles_wrapper.js
@@ -1,0 +1,46 @@
+import MBTiles from '@mapbox/mbtiles';
+import util from 'node:util';
+
+/**
+ * Promise-ful wrapper around the MBTiles class.
+ */
+class MBTilesWrapper {
+  constructor(mbtiles) {
+    this._mbtiles = mbtiles;
+    this._getInfoP = util.promisify(mbtiles.getInfo.bind(mbtiles));
+  }
+
+  /**
+   * Get the underlying MBTiles object.
+   * @returns {MBTiles}
+   */
+  getMbTiles() {
+    return this._mbtiles;
+  }
+
+  /**
+   * Get the MBTiles metadata object.
+   * @returns {Promise<object>}
+   */
+  getInfo() {
+    return this._getInfoP();
+  }
+}
+
+/**
+ * Open the given MBTiles file and return a promise that resolves with a
+ * MBTilesWrapper instance.
+ * @param inputFile Input file
+ * @returns {Promise<MBTilesWrapper>}
+ */
+export function openMbTilesWrapper(inputFile) {
+  return new Promise((resolve, reject) => {
+    const mbtiles = new MBTiles(inputFile + '?mode=ro', (err) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve(new MBTilesWrapper(mbtiles));
+    });
+  });
+}


### PR DESCRIPTION
This adds a small wrapper around the `@mapbox/mbtiles` MBTiles class to promisify opening them (instead of callback pyramids).

This opens up avenues to further DRY out the code and make things more async and modern.
