### PR TITLE
Fix: Use blank index to make sure 'public/files/' folder exists in npm package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tileserver-gl",
-  "version": "4.13.2",
+  "version": "4.13.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tileserver-gl",
-      "version": "4.13.2",
+      "version": "4.13.3",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jsse/pbfont": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tileserver-gl",
-  "version": "4.13.2",
+  "version": "4.13.3",
   "description": "Map tile server for JSON GL styles - vector and server side generated raster tiles",
   "main": "src/main.js",
   "bin": "src/main.js",

--- a/public/files/index.html
+++ b/public/files/index.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+</head>
+</html>

--- a/public/files/index.html
+++ b/public/files/index.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
-<head>
-	<meta charset="utf-8">
-</head>
+  <head>
+    <title></title>
+  </head>
+  <body>
+  </body>
 </html>


### PR DESCRIPTION
.gitignore gets ignored when the npm package gets published. This causes the public/files folder added in https://github.com/maptiler/tileserver-gl/pull/1326 to not exist, which is problem when using the npm package directly as a global install.

This PR changes the placeholder file to a blank index file, which make the folder get included.

This should fix this error in v4.13.2 which is caused by the files folder not being included
![image](https://github.com/user-attachments/assets/762de73a-249a-4add-b9f3-aafabcc3de02)
