### PR TITLE
feat: add progressive rendering option for static jpeg images

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -94,7 +94,8 @@ Use ``false`` to disable the front page altogether (404).
 -----------------
 
 You can use this to specify options for the generation of images in the supported file formats.
-For JPEG and WebP, the only supported option is ``quality`` [0-100].
+For WebP, the only supported option is ``quality`` [0-100].
+For JPEG, the only supported options are ``quality`` [0-100] and ``progressive`` [true, false]. 
 For PNG, the full set of options `exposed by the sharp library <https://sharp.pixelplumbing.com/api-output#png>`_ is available, except ``force`` and ``colours`` (use ``colors``). If not set, their values are the defaults from ``sharp``.
 
 For example::

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -527,7 +527,10 @@ const respondImage = (
           dither: formatOptions.dither,
         });
       } else if (format === 'jpeg') {
-        image.jpeg({ quality: formatOptions.quality || formatQuality || 80 });
+        image.jpeg({
+          quality: formatOptions.quality || formatQuality || 80,
+          progressive: formatOptions.progressive,
+        });
       } else if (format === 'webp') {
         image.webp({ quality: formatOptions.quality || formatQuality || 90 });
       }


### PR DESCRIPTION
Adds support for progessive rendering of static jpeg images via the ``formatOptions``.
In my testing, progressive jpegs were ~2% smaller in filesize than their non-progressive counterparts.
They also 'feel' faster because they become more sharp while loading instead of loading in rows from top to bottom.

Also updated the section in the docs.