### PR TITLE
feat: add support for x-forward-port header

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -50,6 +50,12 @@ const getUrlObject = (req) => {
   // support overriding hostname by sending X-Forwarded-Host http header
   urlObject.hostname = req.hostname;
 
+  // support overriding port by sending X-Forwarded-Port http header
+  const xForwardedPort = req.get('X-Forwarded-Port');
+  if (xForwardedPort) {
+    urlObject.port = xForwardedPort;
+  }
+
   // support add url prefix by sending X-Forwarded-Path http header
   const xForwardedPath = req.get('X-Forwarded-Path');
   if (xForwardedPath) {


### PR DESCRIPTION
Fixes #1422 

Hello, I've opened this PR to add support for the `X-Forwarded-Port` which can be very helpful when setting up a proxy in front of the tileserver. This is especially useful when the proxy and the tileserver are running on different ports.