### PR TITLE
Fix failing test due to updated path-to-regexp

### DIFF
--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -855,7 +855,7 @@ export const serve_rendered = {
       );
     }
 
-    app.get('/(:tileSize(256|512)/)?:id.json', (req, res, next) => {
+    app.get('/(:tileSize(256|512)/)?:id([^/]+).json', (req, res, next) => {
       const item = repo[req.params.id];
       if (!item) {
         return res.sendStatus(404);

--- a/test/static.js
+++ b/test/static.js
@@ -123,10 +123,11 @@ describe('Static endpoints', function () {
       });
 
       describe('different parameters', function () {
-        testStatic(prefix, '-180,-90,180,90/20x20', 'png', 200, 2);
+        //invalid center
+        testStatic(prefix, '-180,-90,180,90/20x20', 'png', 400, 2);
         testStatic(prefix, '0,0,1,1/200x200', 'png', 200, 3);
-
-        testStatic(prefix, '-280,-80,0,80/280x160', 'png', 200);
+        //invalid center
+        testStatic(prefix, '-280,-80,0,80/280x160', 'png', 400);
       });
     });
 

--- a/test/static.js
+++ b/test/static.js
@@ -123,15 +123,16 @@ describe('Static endpoints', function () {
       });
 
       describe('different parameters', function () {
-        //invalid center
-        testStatic(prefix, '-180,-90,180,90/20x20', 'png', 400, 2);
+        testStatic(prefix, '-180,-80,0,80/280x160', 'png', 200);
+        testStatic(prefix, '-180,-80,180,80/20x20', 'png', 200, 2);
         testStatic(prefix, '0,0,1,1/200x200', 'png', 200, 3);
-        //invalid center
-        testStatic(prefix, '-280,-80,0,80/280x160', 'png', 400);
       });
     });
 
     describe('invalid requests return 4xx', function () {
+      //invalid center
+      testStatic(prefix, '-280,-80,0,80/280x160', 'png', 400);
+      testStatic(prefix, '-180,-90,180,90/20x20', 'png', 400, 2);
       testStatic(prefix, '0,87,1,88/5x2', 'png', 400);
 
       testStatic(prefix, '0,0,1,1/1x1', 'gif', 400);


### PR DESCRIPTION
Workaround was found here: https://github.com/pillarjs/path-to-regexp/security/advisories/GHSA-9wv6-86v2-598j

Should fix/support #1412.