### PR TITLE
Fix wrong node version in docker final image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN mkdir -p /etc/apt/keyrings; \
     curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg; \
-    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list; \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list; \
     apt-get -qq update; \
     apt-get install -y nodejs; \
     npm i -g npm@latest; \

--- a/Dockerfile_test
+++ b/Dockerfile_test
@@ -13,7 +13,8 @@ RUN set -ex; \
       unzip \
       build-essential \
       ca-certificates \
-      wget \
+      curl \
+      gnupg \
       pkg-config \
       xvfb \
       libglfw3-dev \
@@ -25,16 +26,33 @@ RUN set -ex; \
       libjpeg-dev \
       libgif-dev \
       librsvg2-dev \
+      gir1.2-rsvg-2.0 \
+      librsvg2-2 \
+      librsvg2-common \
       libcurl4-openssl-dev \
-      libpixman-1-dev; \
-    wget -qO- https://deb.nodesource.com/setup_18.x | bash; \
+      libpixman-1-dev \
+      libpixman-1-0; \
+    apt-get -y --purge autoremove; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*;
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN mkdir -p /etc/apt/keyrings; \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg; \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list; \
+    apt-get -qq update; \
     apt-get install -y nodejs; \
-    apt-get clean;
+    npm i -g npm@latest; \
+    apt-get -y remove gnupg; \
+    apt-get -y --purge autoremove; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*;
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-RUN wget -O test_data.zip https://github.com/maptiler/tileserver-gl/releases/download/v1.3.0/test_data.zip; \
+RUN curl -L -o test_data.zip https://github.com/maptiler/tileserver-gl/releases/download/v1.3.0/test_data.zip; \
     unzip -q test_data.zip -d test_data
 
 COPY package.json .

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tileserver-gl",
-  "version": "5.1.0",
+  "version": "5.1.1-pre.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tileserver-gl",
-      "version": "5.1.0",
+      "version": "5.1.1-pre.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jsse/pbfont": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tileserver-gl",
-  "version": "5.1.0",
+  "version": "5.1.1-pre.0",
   "description": "Map tile server for JSON GL styles - vector and server side generated raster tiles",
   "main": "src/main.js",
   "bin": "src/main.js",


### PR DESCRIPTION
I updated the node version of the builder to node 22 in https://github.com/maptiler/tileserver-gl/pull/1438, but forgot to update it in the final image, so docker build is failing with this error v5.1.0

![image](https://github.com/user-attachments/assets/87590f2c-1137-4b24-b163-5642bdc6dab5)
