### PR TITLE
Fix SIGHUP (broken since 5.1.x)

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -775,8 +775,8 @@ export async function server(opts) {
     console.log(`Caught signal ${signal}, refreshing`);
     console.log('Stopping server and reloading config');
 
-    running.server.shutdown(() => {
-      const restarted = start(opts);
+    running.server.shutdown(async () => {
+      const restarted = await start(opts);
       running.server = restarted.server;
       running.app = restarted.app;
     });


### PR DESCRIPTION
Since #1429  the start function ["async function start(opts)"](https://github.com/maptiler/tileserver-gl/blame/9bb270b6c577576324046c76303b0d20a9654326/src/server.js#L42) is async, so we have to (a)wait for it during reload otherwise the object is incomplete and the tileserver crashes.