### PR TITLE
Fix SIGUP Memory Leak

### DIFF
--- a/src/serve_light.js
+++ b/src/serve_light.js
@@ -6,6 +6,7 @@ export const serve_rendered = {
   init: (options, repo, programOpts) => {},
   add: (options, repo, params, id, programOpts, dataResolver) => {},
   remove: (repo, id) => {},
+  clear: (repo) => {},
   getTerrainElevation: (data, param) => {
     param['elevation'] = 'not supported in light';
     return param;

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -15,7 +15,6 @@ import '@maplibre/maplibre-gl-native';
 import advancedPool from 'advanced-pool';
 import path from 'path';
 import url from 'url';
-import util from 'util';
 import sharp from 'sharp';
 import clone from 'clone';
 import Color from 'color';
@@ -1458,7 +1457,25 @@ export const serve_rendered = {
     }
     delete repo[id];
   },
-
+  /**
+   * Removes all items from the repository.
+   * @param {object} repo Repository object.
+   * @returns {void}
+   */
+  clear: function (repo) {
+    Object.keys(repo).forEach((id) => {
+      const item = repo[id];
+      if (item) {
+        item.map.renderers.forEach((pool) => {
+          pool.close();
+        });
+        item.map.renderersStatic.forEach((pool) => {
+          pool.close();
+        });
+      }
+      delete repo[id];
+    });
+  },
   /**
    * Get the elevation of terrain tile data by rendering it to a canvas image
    * @param {object} data The background color (or empty string for transparent).

--- a/src/server.js
+++ b/src/server.js
@@ -743,6 +743,7 @@ async function start(opts) {
     app,
     server,
     startupPromise,
+    serving,
   };
 }
 /**
@@ -777,8 +778,13 @@ export async function server(opts) {
 
     running.server.shutdown(async () => {
       const restarted = await start(opts);
+      if (!isLight) {
+        serve_rendered.clear(running.serving.rendered);
+      }
       running.server = restarted.server;
       running.app = restarted.app;
+      running.startupPromise = restarted.startupPromise;
+      running.serving = restarted.serving;
     });
   });
   return running;


### PR DESCRIPTION
This addresses #585 and may address #1383.

I stepped down the code and found out, that the memory issue does not apply to the light build. After some debugging I found
https://github.com/maptiler/tileserver-gl/blob/a245126c20400e76d851e269c0381dbdde926b5e/src/serve_rendered.js#L1060
and 
https://github.com/maptiler/tileserver-gl/blob/a245126c20400e76d851e269c0381dbdde926b5e/src/serve_rendered.js#L1220

I assumed that these are not found by the garbage collector because there is a reference somewhere, to I added an explicit cleanup function `clear`, which required the before inaccessible `serving` to handle the `repo`.

As a result I have no more increasing memory with reloading by SIGHUP.