### PR TITLE
Improve support for X-Forwarded-Path

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -476,7 +476,8 @@ async function start(opts) {
           if (data) {
             data['server_version'] =
               `${packageJson.name} v${packageJson.version}`;
-            data['public_url'] = opts.publicUrl || '/';
+            let xForwardedPath = req.get('X-Forwarded-Path') ? '/' + req.get('X-Forwarded-Path') : '';
+            data['public_url'] = opts.publicUrl || xForwardedPath + '/';
             data['is_light'] = isLight;
             data['key_query_part'] = req.query.key
               ? `key=${encodeURIComponent(req.query.key)}&amp;`

--- a/src/server.js
+++ b/src/server.js
@@ -658,11 +658,12 @@ async function start(opts) {
     if (opts.publicUrl) {
       baseUrl = opts.publicUrl;
     } else {
+      let xForwardedPath = req.get('X-Forwarded-Path') ? '/' + req.get('X-Forwarded-Path') : '';
       baseUrl = `${
         req.get('X-Forwarded-Protocol')
           ? req.get('X-Forwarded-Protocol')
           : req.protocol
-      }://${req.get('host')}/`;
+      }://${req.get('host')}${xForwardedPath}/`;
     }
 
     return {


### PR DESCRIPTION
X-Forwarded-Path is already supported in e.g. getTileUrls() from utils.js, but missing in other places.

This fixes the urls with X-Forwarded-Path for all templates (data.tmpl, viewer.tmpl, index.tmpl, wmts.tmpl).

This pull request adds support to the public_url from serveTemplate() function, used by data.tmpl, viewer.tmpl and index.tmpl. Additionally it adds support to baseUrl from serving wmts.xml.
