### PR TITLE
fix: resolves Unimplemented type: 3 error for geojson format

### DIFF
--- a/src/serve_data.js
+++ b/src/serve_data.js
@@ -117,8 +117,7 @@ export const serve_data = {
       if (isGzipped) {
           data = await gunzipP(data);
           isGzipped = false;
-      }      
-      delete headers['Content-Encoding'];
+      }
       
       if (tileJSONFormat === 'pbf') {
         if (options.dataDecoratorFunc) {

--- a/src/serve_data.js
+++ b/src/serve_data.js
@@ -21,7 +21,7 @@ import { openMbTilesWrapper } from './mbtiles_wrapper.js';
 
 import fs from 'node:fs';
 import { fileURLToPath } from 'url';
-import zlib from 'zlib';
+
 const packageJson = JSON.parse(
   fs.readFileSync(
     path.dirname(fileURLToPath(import.meta.url)) + '/../package.json',

--- a/src/serve_data.js
+++ b/src/serve_data.js
@@ -261,8 +261,8 @@ export const serve_data = {
 
         let data = fetchTile.data;
         var param = {
-          long: bbox[0],
-          lat: bbox[1],
+          long: bbox[0].toFixed(7),
+          lat: bbox[1].toFixed(7),
           encoding,
           format,
           tile_size: TILE_SIZE,

--- a/src/serve_data.js
+++ b/src/serve_data.js
@@ -115,10 +115,10 @@ export const serve_data = {
       let isGzipped = data.slice(0, 2).indexOf(Buffer.from([0x1f, 0x8b])) === 0;
 
       if (isGzipped) {
-          data = await gunzipP(data);
-          isGzipped = false;
+        data = await gunzipP(data);
+        isGzipped = false;
       }
-      
+
       if (tileJSONFormat === 'pbf') {
         if (options.dataDecoratorFunc) {
           data = options.dataDecoratorFunc(


### PR DESCRIPTION
We were stuck receiving the unimplemented type 3 error when updating to version 5.x. Moved the isGzipped condition outside the tileJSONformat condition and removed content-encoding headers resolves the issue. 