### PR TITLE
feat: Fix getPublicUrl to handle relative and absolute URLs

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -119,7 +119,11 @@ function getUrlObject(req) {
  */
 export function getPublicUrl(publicUrl, req) {
   if (publicUrl) {
-    return publicUrl;
+    try {
+      return new URL(publicUrl).toString();
+    } catch {
+      return new URL(publicUrl, getUrlObject(req)).toString();
+    }
   }
   return getUrlObject(req).toString();
 }


### PR DESCRIPTION
This PR updates the getPublicUrl function to handle relative publicUrl values. When a relative URL is provided, it is automatically converted to an absolute URL based on the request context. If an absolute URL is provided, it is returned as-is.

User story:

I encountered an issue while setting up an Nginx proxy with a prefix for the tileserver. The main problem was when I needed to specify the entire absolute URL using -u|--public_url <url> (because when fetching .pbf tiles, the relative URLs didn't work). In scenarios where I don't know the domain the server will be used on, I needed a way to rely on absolute URLs. I believe this PR will help with this scenario, and I'm sure others may face a similar issue. 😄