### PR TITLE
Fix invalid Delete of 'prepare' Script required for Light Build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # tileserver-gl changelog
 
+## 5.2.1
+* Fix invalid Delete of 'prepare' Script required for Light Build (https://github.com/maptiler/tileserver-gl/pull/1489) by @okimiko
+
+
 ## 5.2.0
 * Use npm packages for public/resources (https://github.com/maptiler/tileserver-gl/pull/1427) by @okimiko
 * use ttf files of googlefonts/opensans (https://github.com/maptiler/tileserver-gl/pull/1447) by @okimiko

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tileserver-gl",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tileserver-gl",
-      "version": "5.2.0",
+      "version": "5.2.1",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jsse/pbfont": "^0.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10225,9 +10225,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.2.tgz",
+      "integrity": "sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==",
       "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tileserver-gl",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "Map tile server for JSON GL styles - vector and server side generated raster tiles",
   "main": "src/main.js",
   "bin": "src/main.js",

--- a/publish.js
+++ b/publish.js
@@ -37,8 +37,6 @@ delete packageJson.dependencies['canvas'];
 delete packageJson.dependencies['@maplibre/maplibre-gl-native'];
 delete packageJson.dependencies['sharp'];
 
-delete packageJson.scripts['prepare'];
-
 delete packageJson.optionalDependencies;
 delete packageJson.devDependencies;
 


### PR DESCRIPTION
As stated in #1488 the remove of the 'prepare' script breaks the light npm build. This PR reverts the change.