### PR TITLE
Include public\resources js files on npm publish by specifying included files in package.json

### DIFF
--- a/.github/workflows/ct.yml
+++ b/.github/workflows/ct.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Install dependencies 🚀
         run: npm ci --prefer-offline --no-audit
 
+      - name: Test Publish
+        run: npm publish --dry-run
+
       - name: Pull test data 📦
         run: >-
           wget -O test_data.zip
@@ -73,6 +76,10 @@ jobs:
 
       - name: Install node dependencies
         run: npm ci --prefer-offline --no-audit
+        working-directory: ./light
+
+      - name: Test Light Publish
+        run: npm publish --dry-run
         working-directory: ./light
 
       - name: Test Light Version to Docker Hub

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # tileserver-gl changelog
 
+## 5.2.2-pre.0
+* Fix - Include public\resources js files on npm publish by specifying included files in package.json (https://github.com/maptiler/tileserver-gl/pull/1490) by @acalcutt
+
+
 ## 5.2.1
 * Fix invalid Delete of 'prepare' Script required for Light Build (https://github.com/maptiler/tileserver-gl/pull/1489) by @okimiko
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "tileserver-gl",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tileserver-gl",
-      "version": "5.2.1",
+      "version": "5.2.2",
+      "hasInstallScript": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jsse/pbfont": "^0.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tileserver-gl",
-  "version": "5.2.1",
+  "version": "5.2.2-pre.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tileserver-gl",
-      "version": "5.2.1",
+      "version": "5.2.2-pre.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jsse/pbfont": "^0.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,12 @@
 {
   "name": "tileserver-gl",
-  "version": "5.2.2",
+  "version": "5.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tileserver-gl",
-      "version": "5.2.2",
-      "hasInstallScript": true,
+      "version": "5.2.1",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jsse/pbfont": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "public",
     "test",
     "package.json",
-    "package-lock.json",
     "CHANGELOG.md",
     "README.md",
     "LICENSE"

--- a/package.json
+++ b/package.json
@@ -5,6 +5,17 @@
   "main": "src/main.js",
   "bin": "src/main.js",
   "type": "module",
+  "files": [
+    "docs",
+    "src",
+    "public",
+    "test",
+    "package.json",
+    "package-lock.json",
+    "CHANGELOG.md",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "prepare": "npm run copy:maplibre && npm run copy:maplibre-inspect && npm run copy:mapbox-rtl-text && npm run copy:leaflet && npm run copy:leaflet-hash",
     "copy:maplibre": "copyfiles -EVf node_modules/maplibre-gl/dist/maplibre-gl.js node_modules/maplibre-gl/dist/maplibre-gl.js.map node_modules/maplibre-gl/dist/maplibre-gl.css public/resources/",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "tileserver-gl",
-  "version": "5.2.2",
+  "version": "5.2.1",
   "description": "Map tile server for JSON GL styles - vector and server side generated raster tiles",
   "main": "src/main.js",
   "bin": "src/main.js",
   "type": "module",
   "scripts": {
-    "postinstall": "npm run copy:maplibre && npm run copy:maplibre-inspect && npm run copy:mapbox-rtl-text && npm run copy:leaflet && npm run copy:leaflet-hash",
+    "prepare": "npm run copy:maplibre && npm run copy:maplibre-inspect && npm run copy:mapbox-rtl-text && npm run copy:leaflet && npm run copy:leaflet-hash",
     "copy:maplibre": "copyfiles -EVf node_modules/maplibre-gl/dist/maplibre-gl.js node_modules/maplibre-gl/dist/maplibre-gl.js.map node_modules/maplibre-gl/dist/maplibre-gl.css public/resources/",
     "copy:maplibre-inspect": "copyfiles -EVf node_modules/@maplibre/maplibre-gl-inspect/dist/maplibre-gl-inspect.js node_modules/@maplibre/maplibre-gl-inspect/dist/maplibre-gl-inspect.js.map node_modules/@maplibre/maplibre-gl-inspect/dist/maplibre-gl-inspect.css  public/resources/",
     "copy:mapbox-rtl-text": "copyfiles -EVf node_modules/@mapbox/mapbox-gl-rtl-text/dist/mapbox-gl-rtl-text.js public/resources/",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "tileserver-gl",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "description": "Map tile server for JSON GL styles - vector and server side generated raster tiles",
   "main": "src/main.js",
   "bin": "src/main.js",
   "type": "module",
   "scripts": {
-    "prepare": "npm run copy:maplibre && npm run copy:maplibre-inspect && npm run copy:mapbox-rtl-text && npm run copy:leaflet && npm run copy:leaflet-hash",
+    "postinstall": "npm run copy:maplibre && npm run copy:maplibre-inspect && npm run copy:mapbox-rtl-text && npm run copy:leaflet && npm run copy:leaflet-hash",
     "copy:maplibre": "copyfiles -EVf node_modules/maplibre-gl/dist/maplibre-gl.js node_modules/maplibre-gl/dist/maplibre-gl.js.map node_modules/maplibre-gl/dist/maplibre-gl.css public/resources/",
     "copy:maplibre-inspect": "copyfiles -EVf node_modules/@maplibre/maplibre-gl-inspect/dist/maplibre-gl-inspect.js node_modules/@maplibre/maplibre-gl-inspect/dist/maplibre-gl-inspect.js.map node_modules/@maplibre/maplibre-gl-inspect/dist/maplibre-gl-inspect.css  public/resources/",
     "copy:mapbox-rtl-text": "copyfiles -EVf node_modules/@mapbox/mapbox-gl-rtl-text/dist/mapbox-gl-rtl-text.js public/resources/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tileserver-gl",
-  "version": "5.2.1",
+  "version": "5.2.2-pre.0",
   "description": "Map tile server for JSON GL styles - vector and server side generated raster tiles",
   "main": "src/main.js",
   "bin": "src/main.js",


### PR DESCRIPTION
Second attempt to fix https://github.com/maptiler/tileserver-gl/issues/1488

When tileserver-gl is installed as a global package, it does not run the prepare scripts (as npm intends). this means none of the js files get copied. 

The prepare script should make these files get included in the published package, but because we included them in .gitignore they are getting excluded.

I have read having specifying the files though package.json is preferable to making a .npmignore that differs from .gitignore, so that is what this PR does. I have also added a test publish to the ct workflow, so we can see the files that will be published.