### PR TITLE
v5.3.0-pre.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # tileserver-gl changelog
 
-## 5.3.0-pre.0
+## 5.3.0-pre.1
 * Fix - Include public\resources js files on npm publish by specifying included files in package.json (https://github.com/maptiler/tileserver-gl/pull/1490) by @acalcutt
 * Fix - Various Updates and Fix RTL Plugin Load (https://github.com/maptiler/tileserver-gl/pull/1489) by @okimiko
 * Updates Maplibre-gl-js to v5 and adds globe support.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tileserver-gl",
-  "version": "5.3.0-pre.0",
+  "version": "5.3.0-pre.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tileserver-gl",
-      "version": "5.3.0-pre.0",
+      "version": "5.3.0-pre.1",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jsse/pbfont": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tileserver-gl",
-  "version": "5.3.0-pre.0",
+  "version": "5.3.0-pre.1",
   "description": "Map tile server for JSON GL styles - vector and server side generated raster tiles",
   "main": "src/main.js",
   "bin": "src/main.js",


### PR DESCRIPTION
Bump version so failed tileserver-light docker build can be republished