### PR TITLE
Rasters: Add `tileSize` to TileJSON

### DIFF
--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -1005,7 +1005,7 @@ export const serve_rendered = {
         );
       }
       const info = clone(item.tileJSON);
-      info.tileSize = (tileSize != undefined ? tileSize : 256);
+      info.tileSize = tileSize != undefined ? tileSize : 256;
       info.tiles = getTileUrls(
         req,
         info.tiles,

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -1005,6 +1005,7 @@ export const serve_rendered = {
         );
       }
       const info = clone(item.tileJSON);
+      info.tileSize = (tileSize != undefined ? tileSize : 256)
       info.tiles = getTileUrls(
         req,
         info.tiles,

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -1005,7 +1005,7 @@ export const serve_rendered = {
         );
       }
       const info = clone(item.tileJSON);
-      info.tileSize = (tileSize != undefined ? tileSize : 256)
+      info.tileSize = (tileSize != undefined ? tileSize : 256);
       info.tiles = getTileUrls(
         req,
         info.tiles,


### PR DESCRIPTION
### Add `tileSize` to TileJSON Output for Raster endpoints

1.  This PR would  add to the Tile JSON implementation:
  i. `tileSize`
2.  The [TileJSON 3.0.0](https://github.com/mapbox/tilejson-spec/tree/master/3.0.0) spec is missing a Tile Size concept for rasters.
  i. There is discussion at [tilejson-spec#26](https://github.com/mapbox/tilejson-spec/issues/26).  
  ii. The Sources spec for [Mapbox](https://docs.mapbox.com/style-spec/reference/sources/#raster-array-tileSize) & [MapLibre](https://maplibre.org/maplibre-style-spec/sources/#tilesize) make use of `tileSize`.  
---

### Tests

Using the default Zurich tile set with a basic preview.  Paths are mentioned in the docs at [Rendered Tiles](https://tileserver.readthedocs.io/en/latest/endpoints.html#rendered-tiles).

> "*The optional tile size `/{tileSize}` (ex. `/256`, `/512`). If omitted, tileSize defaults to 256.*"

* TileJSON output without a tileSize set:
  * `http://localhost:8080/styles/basic-preview.json`
```json
  "tiles": [ "http://localhost:8080/styles/basic-preview/{z}/{x}/{y}.png" ],
  "tileSize": 256
```

* TileJSON output with tileSize set to 256:
  * `http://localhost:8080/styles/256/basic-preview.json`
```json
  "tiles": [ "http://localhost:8080/styles/basic-preview/256/{z}/{x}/{y}.png" ],
  "tileSize": 256
```

* TileJSON output with tileSize set to 512:
  * `http://localhost:8080/styles/512/basic-preview.json`
```json
  "tiles": [ "http://localhost:8080/styles/basic-preview/512/{z}/{x}/{y}.png" ],
  "tileSize": 512
```

<small>*Note:  the path to the TileJSON does not exactly match the pattern for the path the PNG, but those are the verified paths.*</small>

---

### Note on TileJSON `2.0.0` v. TileJSON `3.0.0`++

* [TileJSON `2.0.0`#2. File format](https://github.com/mapbox/tilejson-spec/blob/master/2.0.0/README.md) discusses how to deal with extra keys:  "*implementations MUST expose unknown key/values in their API so that API users can optionally handle these keys*"