### PR TITLE
fix the issue of being unable to correctly parse the HTTPS protocol when using an nginx proxy service

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -198,9 +198,10 @@ export function getTileUrls(
   const uris = [];
   if (!publicUrl) {
     let xForwardedPath = `${req.get('X-Forwarded-Path') ? '/' + req.get('X-Forwarded-Path') : ''}`;
+    let protocol = req.get('X-Forwarded-Protocol') ? req.get('X-Forwarded-Protocol') : req.protocol;
     for (const domain of domains) {
       uris.push(
-        `${req.protocol}://${domain}${xForwardedPath}/${path}/${tileParams}${format}${query}`,
+        `${protocol}://${domain}${xForwardedPath}/${path}/${tileParams}${format}${query}`,
       );
     }
   } else {


### PR DESCRIPTION
fix the issue of being unable to correctly parse the HTTPS protocol when using an nginx proxy service