### PR TITLE
Fix the issue where the tile URL cannot be correctly parsed with the …

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -198,9 +198,12 @@ export function getTileUrls(
   const uris = [];
   if (!publicUrl) {
     let xForwardedPath = `${req.get('X-Forwarded-Path') ? '/' + req.get('X-Forwarded-Path') : ''}`;
+    let protocol = req.get('X-Forwarded-Protocol')
+      ? req.get('X-Forwarded-Protocol')
+      : req.protocol;
     for (const domain of domains) {
       uris.push(
-        `${req.protocol}://${domain}${xForwardedPath}/${path}/${tileParams}${format}${query}`,
+        `${protocol}://${domain}${xForwardedPath}/${path}/${tileParams}${format}${query}`,
       );
     }
   } else {


### PR DESCRIPTION
Fix the issue where the tile URL cannot be correctly parsed with the HTTPS protocol when using an nginx proxy service.