### PR TITLE
Workaround for 'hillshade-method' not yet being suported in maplibre-native

### DIFF
--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -1280,9 +1280,25 @@ export const serve_rendered = {
 
         // Remove (flatten) 3D buildings
         if (layer.paint['fill-extrusion-height']) {
+          if (verbose) {
+            console.warn(
+              `Warning: Layer '${layerIdForWarning}' in style '${id}' has property 'fill-extrusion-height'. ` +
+                `3D extrusion may appear distorted or misleading when rendered as a static image due to camera angle limitations. ` +
+                `It will be flattened (set to 0) in rendered images. ` +
+                `Note: This property will still work with MapLibre GL JS vector maps.`,
+            );
+          }
           layer.paint['fill-extrusion-height'] = 0;
         }
         if (layer.paint['fill-extrusion-base']) {
+          if (verbose) {
+            console.warn(
+              `Warning: Layer '${layerIdForWarning}' in style '${id}' has property 'fill-extrusion-base'. ` +
+                `3D extrusion may appear distorted or misleading when rendered as a static image due to camera angle limitations. ` +
+                `It will be flattened (set to 0) in rendered images. ` +
+                `Note: This property will still work with MapLibre GL JS vector maps.`,
+            );
+          }
           layer.paint['fill-extrusion-base'] = 0;
         }
 


### PR DESCRIPTION
Attempt to fix  https://github.com/maptiler/tileserver-gl/issues/1563 and fix https://github.com/maptiler/tileserver-gl/issues/1598 . Works around 'hillshade-method' not yet being supported in maplibre-native by deleting that property when maplibre-native loads the style. this will make maplibre-native use the old mapbox style hillshade that maplibre-native supports right now.

This would be temporary until support for hillshade-method in maplibre-native can be added, See https://github.com/maplibre/maplibre-native/issues/3563