### PR TITLE
bump version to test release workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # tileserver-gl changelog
 
+## 5.4.1-pre.0
+* This release is only to test the new release workflow (https://github.com/maptiler/tileserver-gl/pull/1685)
+
 ## 5.4.0
 * Fix the issue where the tile URL cannot be correctly parsed with the HTTPS protocol when using an nginx proxy service (https://github.com/maptiler/tileserver-gl/pull/1578) by @dakanggo
 * Use jemalloc as memory allocator in the docker image (https://github.com/maptiler/tileserver-gl/pull/1574) by @MichielMortier

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tileserver-gl",
-  "version": "5.4.0",
+  "version": "5.4.1-pre.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tileserver-gl",
-      "version": "5.4.0",
+      "version": "5.4.1-pre.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jsse/pbfont": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tileserver-gl",
-  "version": "5.4.0",
+  "version": "5.4.1-pre.0",
   "description": "Map tile server for JSON GL styles - vector and server side generated raster tiles",
   "main": "src/main.js",
   "bin": "src/main.js",


### PR DESCRIPTION
A new release workflow was added in https://github.com/maptiler/tileserver-gl/pull/1685 . I have tested it in my fork, but this PR will test it here.