### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete string escaping or encoding

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -166,7 +166,7 @@ export function getTileUrls(
       if (domain.indexOf('*') !== -1) {
         if (relativeSubdomainsUsable) {
           const newParts = hostParts.slice(1);
-          newParts.unshift(domain.replace('*', hostParts[0]));
+          newParts.unshift(domain.replace(/\*/g, hostParts[0]));
           newDomains.push(newParts.join('.'));
         }
       } else {


### PR DESCRIPTION
Potential fix for [https://github.com/maptiler/tileserver-gl/security/code-scanning/3](https://github.com/maptiler/tileserver-gl/security/code-scanning/3)

To fix the problem, we need to ensure that all occurrences of the wildcard character (`*`) in the domain string are replaced, not just the first one. This is achieved by replacing `.replace('*', hostParts[0])` with `.replace(/\*/g, hostParts[0])`, which uses a regular expression with the global `g` flag. This change should be made at line 169 of `src/utils.js`. No additional imports or definitions are required, as native JavaScript supports regular expressions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
