### PR TITLE
Potential fix for code scanning alert no. 1610: Useless conditional

### DIFF
--- a/src/serve_data.js
+++ b/src/serve_data.js
@@ -164,9 +164,7 @@ export const serve_data = {
       headers['Content-Encoding'] = 'gzip';
       res.set(headers);
 
-      if (!isGzipped) {
-        data = await gzipP(data);
-      }
+      data = await gzipP(data);
 
       return res.status(200).send(data);
     });


### PR DESCRIPTION
Potential fix for [https://github.com/maptiler/tileserver-gl/security/code-scanning/1610](https://github.com/maptiler/tileserver-gl/security/code-scanning/1610)

We should remove the useless conditional `if (!isGzipped) { ... }` and always run the gzip step, as the code currently always executes gzip regardless of the input's prior compressed state. We need to change lines 167–169 to remove the conditional and just assign the result of `await gzipP(data)` to `data`. There are no required changes to imports or utilities, as the call to `gzipP` is already present and appropriately imported.

No other modifications are necessary, as the rest of the code flow and variable use are unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
