### PR TITLE
Revert maplibre-gl-js from 5.14.0 to 5.13.0 to fix terrain preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 * Fix S3 URL parsing for nested paths in AWS buckets (https://github.com/maptiler/tileserver-gl/pull/1819) by @acalcutt
 * Fix Renderer Crashes and Memory Leak (https://github.com/maptiler/tileserver-gl/pull/1825) by @acalcutt
 * Fix loading local data sources (PMTiles/MBTiles) specified in style (https://github.com/maptiler/tileserver-gl/pull/1855) by @acalcutt
-* **BREAKING**: Change 'sparse' option default based on tile format - vector tiles (pbf) default to false (204), raster tiles default to true (404 for overzoom) by @acalcutt
+* **BREAKING**: Change 'sparse' option default based on tile format - vector tiles (pbf) default to false (204), raster tiles default to true (404 for overzoom) (https://github.com/maptiler/tileserver-gl/pull/1855) by @acalcutt
+* Revert "fix(deps): bump maplibre-gl from 5.13.0 to 5.14.0 (https://github.com/maptiler/tileserver-gl/pull/1853)
 
 ## 5.4.0
 * Fix the issue where the tile URL cannot be correctly parsed with the HTTPS protocol when using an nginx proxy service (https://github.com/maptiler/tileserver-gl/pull/1578) by @dakanggo

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tileserver-gl",
-  "version": "5.5.0-pre.6",
+  "version": "5.5.0-pre.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tileserver-gl",
-      "version": "5.5.0-pre.6",
+      "version": "5.5.0-pre.7",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.946.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tileserver-gl",
-  "version": "5.5.0-pre.6",
+  "version": "5.5.0-pre.7",
   "description": "Map tile server for JSON GL styles - vector and server side generated raster tiles",
   "main": "src/main.js",
   "bin": "src/main.js",


### PR DESCRIPTION
Reverts maptiler/tileserver-gl#1853 due to https://github.com/maplibre/maplibre-gl-js/issues/6822