### PR TITLE
feat: allow public url to be relative

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -206,14 +206,14 @@ export function getTileUrls(
   }
 
   const uris = [];
-  if (!publicUrl) {
-    let xForwardedPath = `${req.get('X-Forwarded-Path') ? '/' + req.get('X-Forwarded-Path') : ''}`;
+  if (!publicUrl || !isValidHttpUrl(publicUrl)) {
+    let xForwardedPath = publicUrl || `${req.get('X-Forwarded-Path') ? '/' + req.get('X-Forwarded-Path') : ''}`;
     let protocol = req.get('X-Forwarded-Protocol')
       ? req.get('X-Forwarded-Protocol')
       : req.protocol;
     for (const domain of domains) {
       uris.push(
-        `${protocol}://${domain}${xForwardedPath}/${path}/${tileParams}${format}${query}`,
+        `${protocol}://${domain}${xForwardedPath.replace(/\/$/, "")}/${path}/${tileParams}${format}${query}`,
       );
     }
   } else {


### PR DESCRIPTION
This change is required to compute an absolute URL when the provided public URL is relative. A relative public URL is useful when the tileserver is deployed behind a reverse proxy that handles multiple domains.