### PR TITLE
fix: use callback() for missing raster-dem tiles to prevent segfault

### DIFF
--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -1449,7 +1449,8 @@ export const serve_rendered = {
                 // eslint-disable-next-line security/detect-object-injection -- sourceId from internal style source names
                 const sparse = map.sparseFlags[sourceId] ?? true;
                 // sparse=true (default) -> return empty callback so MapLibre can overzoom
-                if (sparse) {
+                // raster-dem: 1x1 placeholder causes backfillBorder segfault (#2065)
+                if (sparse || sourceInfo.type === 'raster-dem') {
                   callback();
                   return;
                 }


### PR DESCRIPTION
## Summary

When the internal renderer (`serve_rendered.js`) requests a tile from a local mbtiles/pmtiles source and the tile doesn't exist, `createEmptyResponse()` generates a 1×1 pixel PNG. For `raster-dem` sources, this 1×1 PNG is passed to maplibre-native as valid DEM tile data. When `DEMData::backfillBorder()` later runs between this tile and a real 256×256 neighbor, the dimension mismatch causes an out-of-bounds memory read — segfault.

This PR adds `sourceInfo.type === 'raster-dem'` to the existing `sparse` check so that missing DEM tiles always take the `callback()` (no-content) path, regardless of the `sparse` flag.

## What changed

One condition added in `src/serve_rendered.js`:

```diff
-                if (sparse) {
+                if (sparse || sourceInfo.type === 'raster-dem') {
```

`callback()` with zero arguments is maplibre-native's designed "no content" path:
1. `TileLoader` → `setData(nullptr)`
2. `raster_dem_tile_worker.cpp` → skips image decoding
3. `raster_dem_tile.cpp` → `renderable = false`
4. `render_raster_dem_source.cpp` → `isRenderable()` returns false → backfill loop skipped

## Why only raster-dem?

`createEmptyResponse` respects `sourceInfo.color` — a source can specify what color empty tiles should be. Changing this for non-DEM sources would be a breaking change. For `raster-dem` sources, `sourceInfo.color` is meaningless (DEM tiles are elevation data, not visual), so `callback()` is strictly correct.

## Risk

Minimal. Since v5.4.0, `sparse` defaults to `true`, so the vast majority of raster-dem sources already hit the `callback()` path. This change only affects the edge case where `sparse` is explicitly set to `false` on a raster-dem source — which can cause a crash depending on memory layout and neighbor tile timing.

Fixes #2065

Related: maplibre/maplibre-native#4160