### PR TITLE
ci: cut a stable release every month on a schedule

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,5 +1,9 @@
 name: Create bump version PR
 on:
+  schedule:
+    # Cut a stable release every month so dependency and security updates
+    # merged into master reach the `latest` npm tag and Docker images.
+    - cron: '0 4 1 * *'
   workflow_dispatch:
     inputs:
       version:
@@ -31,6 +35,87 @@ jobs:
         with:
           fetch-depth: 0
           ref: master
+      - name: Resolve release type
+        id: release-type
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_PREID: ${{ inputs.preid }}
+        run: |
+          # How long to leave a fresh prerelease or major dependency bump alone
+          # before a scheduled run will promote it to stable.
+          SETTLE_DAYS=7
+
+          bump="$INPUT_VERSION"
+          preid="$INPUT_PREID"
+
+          # Manual dispatch uses whatever was asked for.
+          if [ -n "$bump" ]; then
+            echo "Manual dispatch: bump=$bump preid=${preid:-<none>}"
+            echo "bump=$bump" >> "$GITHUB_OUTPUT"
+            echo "preid=$preid" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Scheduled runs always cut a stable release, so measure from the last
+          # stable tag rather than the last tag, which is usually a prerelease.
+          tags="$( git tag --list 'v*' --sort=-v:refname )"
+          lastStable="$( awk '!/-/ { print; exit }' <<< "$tags" )"
+          range="${lastStable:+$lastStable..}HEAD"
+          echo "Considering everything since ${lastStable:-the first commit}"
+
+          if [ "$( git rev-list --count "$range" )" -eq 0 ]; then
+            echo "Nothing new to release."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          log="$( git log "$range" --format='%s%n%b' )"
+
+          # Never let the schedule turn a breaking change into a minor release.
+          if grep -qE '^[a-z]+(\(.+\))?!:|^BREAKING[ -]CHANGE' <<< "$log"; then
+            echo "Breaking changes present, a major release has to be dispatched manually."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          now="$( date +%s )"
+
+          # Cutting a prerelease means "not stable yet", so don't overrule a
+          # recent one a few days later.
+          lastTag="$( git describe --tags --abbrev=0 2>/dev/null || true )"
+          case "$lastTag" in
+            *-*)
+              age=$(( ( now - $( git log -1 --format=%ct "$lastTag" ) ) / 86400 ))
+              if [ "$age" -lt "$SETTLE_DAYS" ]; then
+                echo "$lastTag was cut ${age}d ago, leaving it to settle."
+                echo "skip=true" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+              ;;
+          esac
+
+          # Major dependency bumps aren't routine. 5.0.0 came out of a
+          # Maplibre-Native update, which is how breaking changes tend to
+          # reach this project, so give them the same wait.
+          majorDep="$( git log "$range" -1 --fixed-strings --grep='version-update:semver-major' --format='%ct' )"
+          if [ -n "$majorDep" ]; then
+            age=$(( ( now - majorDep ) / 86400 ))
+            if [ "$age" -lt "$SETTLE_DAYS" ]; then
+              echo "A major dependency bump landed ${age}d ago, letting it settle."
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+
+          if [ -n "$majorDep" ] || grep -qE '^feat(\(.+\))?:' <<< "$log"; then
+            bump=minor
+          else
+            bump=patch
+          fi
+
+          echo "Scheduled release: $bump"
+          echo "bump=$bump" >> "$GITHUB_OUTPUT"
+          echo "preid=" >> "$GITHUB_OUTPUT"
       - name: Setup node env 📦
         uses: actions/setup-node@v6
         with:
@@ -38,6 +123,7 @@ jobs:
           check-latest: true
           cache: 'npm'
       - name: Create bump script
+        if: steps.release-type.outputs.skip != 'true'
         run: |
           cat > bump-version.mjs << 'EOF'
           import { execSync } from 'child_process';
@@ -209,12 +295,16 @@ jobs:
           EOF
       - name: Bump version and update changelog
         id: version-details
+        if: steps.release-type.outputs.skip != 'true'
         run: |
-          node bump-version.mjs "${{ inputs.version }}" "${{ inputs.preid }}"
+          node bump-version.mjs "$BUMP" "$PREID"
           rm bump-version.mjs
         env:
           GH_TOKEN: ${{ github.token }}
+          BUMP: ${{ steps.release-type.outputs.bump }}
+          PREID: ${{ steps.release-type.outputs.preid }}
       - name: Create Pull Request
+        if: steps.release-type.outputs.skip != 'true'
         uses: peter-evans/create-pull-request@v8
         with:
           commit-message: Release v${{ steps.version-details.outputs.version }}


### PR DESCRIPTION
Draft for now, want to check this is wanted before I polish it.

### Why

`latest` on npm is `5.6.0` from 2026-04-06. Master is 159 commits ahead of that tag, 153 of them Dependabot bumps that already passed the pipeline and got auto-merged. None of it is on `latest`.

Over the last year the longest `latest` sat without an update was 139 days. Prereleases keep moving on `next`, so the gap is only in promoting something to stable.

### What this does

Adds a `schedule` trigger to `Create bump version PR`, plus a step that works out what a scheduled run should cut.

Manual dispatch is unchanged. If `version` is set, the step passes it and `preid` through untouched, so the prerelease flow works exactly as before.

A scheduled run has no inputs. It looks at what landed since the last stable tag and cuts a stable version: minor if there is a `feat:` commit or a major dependency bump, patch otherwise. If nothing new landed it does nothing.

### When it holds off

If the newest tag is a prerelease less than 7 days old, the run stops. Cutting a prerelease means "not stable yet" and I did not want a cron job overruling that a day later.

Major dependency bumps get the same 7 day wait, and never go out as a patch. `5.0.0` came out of a Maplibre-Native update, so that is the path breaking changes actually take here.

There is also a check for `!:` subjects and `BREAKING CHANGE` footers. Neither appears anywhere in this repo's history, so realistically it will never fire. I left it in as insurance if commitlint ever gets enforced.

Publishing is untouched. The scheduled run just opens the pull request someone would have opened by hand, and `Build, Test, Release` still runs the full amd64 and arm64 matrix on master before anything ships.

### Backtest

I replayed the logic against real history at the last 12 month boundaries. It fires on 7 of them, and the worst `latest` gap drops from 139 days to 63.

All 5 skips are months where a prerelease had been cut 0 to 4 days earlier. You shipped stable within days in January and April anyway, so those were months worth staying out of.

### First run

Newest thing needing a wait since `v5.6.0` is the `commander` 14 to 15 bump from 2026-06-09, so the window has long passed. It is a major dependency bump, so minor. `npm version minor` on a `5.7.0` prerelease drops the prerelease instead of incrementing, giving `5.7.0`, which is what is already staged as `5.7.0-pre.0`.

### Known limitation

Most non-Dependabot commits here do not use conventional prefixes, so something like `Add POST requests for static maps` gets sized as a patch. It under-sizes rather than over-sizes, and you can see the version on the release PR before merging. Fixing it properly means enforcing commitlint in CI, which is configured but not wired up.

### A better version I did not build

Skipping a whole month is a crude answer to "something recent is in here". What you would really want is a train that always fires but cuts at the last commit that has settled, leaving newer work for next month.

Against the same 12 months that fires every time, ships everything in 7 of them, and holds back 25 commits in the worst case.

I did not do it because it needs releases published from a branch or tag, and `release.yml` publishes master HEAD. A release branch cut at an older commit still drags the newer commits in when it merges, so the freeze does not survive. Doing it properly means moving the publish trigger, making the changelog script range aware, and living with tags that are not on master.

That is a lot of surgery on the part of your setup that matters most, and it felt like too much for a first PR from someone you do not know. Glad to write it if you want it.

### Changelog

A Dependabot-only month ends up with a nearly empty changelog section, since the existing script skips Dependabot PRs when collecting entries. Left alone because it is existing behaviour and I do not know what you would want it to say. Easy to add a line about dependency updates if that helps.

### Questions

Is 7 days the right wait, and is 04:00 UTC on the 1st a sensible slot?

Want the scheduled PR labelled, or auto-merged once the pipeline goes green? I left it as a normal PR so you still make the call.
