### PR TITLE
fix: allow native install scripts under npm 12 so canvas builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: npm ci --prefer-offline --no-audit --omit=optional
 
       - name: Rebuild canvas from source 🎨
-        run: npm rebuild canvas --build-from-source
+        run: npm_config_build_from_source=true npm rebuild canvas
 
       - name: Run linter(s) 💅
         uses: wearerequired/lint-action@v2

--- a/.github/workflows/ct.yml
+++ b/.github/workflows/ct.yml
@@ -58,7 +58,7 @@ jobs:
         run: npm ci --prefer-offline --no-audit
 
       - name: Rebuild canvas from source 🎨
-        run: npm rebuild canvas --build-from-source
+        run: npm_config_build_from_source=true npm rebuild canvas
 
       - name: Get release type
         id: prepare_release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
         run: npm ci --prefer-offline --no-audit
 
       - name: Rebuild canvas from source 🎨
-        run: npm rebuild canvas --build-from-source
+        run: npm_config_build_from_source=true npm rebuild canvas
 
       - name: Pull test data 📦
         run: >-

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN npm config set fetch-retries 5 && \
     npm config set fetch-retry-maxtimeout 600000 && \
     npm ci --omit=dev && \
     # Build canvas from source for the Noble architecture
-    npm rebuild canvas --build-from-source && \
+    npm_config_build_from_source=true npm rebuild canvas && \
     chown -R root:root /usr/src/app
 
 # --- Final Stage ---

--- a/Dockerfile_light
+++ b/Dockerfile_light
@@ -41,7 +41,7 @@ RUN npm config set fetch-retries 5 && \
     npm config set fetch-retry-maxtimeout 600000 && \
     npm ci --omit=dev && \
     # Build canvas from source for the Noble architecture
-    npm rebuild canvas --build-from-source && \
+    npm_config_build_from_source=true npm rebuild canvas && \
     chown -R root:root /usr/src/app
 
 # --- Final Stage ---

--- a/Dockerfile_test
+++ b/Dockerfile_test
@@ -55,7 +55,7 @@ RUN curl -L -o test_data.zip https://github.com/maptiler/tileserver-gl/releases/
 
 COPY package.json .
 # Running npm install for development (includes devDependencies for tests)
-RUN npm install && npm rebuild canvas --build-from-source
+RUN npm install && npm_config_build_from_source=true npm rebuild canvas
 COPY / .
 
 # Execute tests using xvfb-run

--- a/package.json
+++ b/package.json
@@ -113,5 +113,10 @@
   "bugs": {
     "url": "https://github.com/maptiler/tileserver-gl/issues"
   },
-  "homepage": "https://github.com/maptiler/tileserver-gl#readme"
+  "homepage": "https://github.com/maptiler/tileserver-gl#readme",
+  "allowScripts": {
+    "canvas": true,
+    "sqlite3": true,
+    "@maplibre/maplibre-gl-native": true
+  }
 }


### PR DESCRIPTION
CT has failed on every run since 2026-07-06. Nothing has merged into master since 2026-07-07 and there are 16 Dependabot pull requests sitting open and blocked on it, several of them security updates.

I reproduced this locally with Docker and verified the fix end to end.

### The visible error

`CT / Test and Build` fails on both arches at the image build step:

```
npm error code EUNKNOWNCONFIG
npm error Unknown cli flag:
npm error   - --build-from-source
```

Recent npm rejects unknown CLI flags rather than quietly turning them into config, so `npm rebuild canvas --build-from-source` is now a hard error.

### The part that actually matters

Fixing only that flag makes the build go green and produces a broken image, which is worse than the current failure. I tried it first, and the result installs no native code at all:

```
npm warn rebuild 3 packages had install scripts blocked because they are not covered by allowScripts
```

No `.node` binaries anywhere in the image, and `require('canvas')` throws `Cannot find module`. Same for `sqlite3` and `@maplibre/maplibre-gl-native`.

The real cause is that npm 12 enforces `allowScripts` and refuses to run dependency install scripts that have not been approved. All three native dependencies build through install scripts, so `npm ci` silently produces an install with no compiled bindings.

This also explains why the runner is fine and only the image breaks. `actions/setup-node` and the official `node:24` image currently ship npm 11.17.0, which only warns about this. The Dockerfile installs Node from NodeSource, and `node_24.x` now ships npm 12.0.2, which enforces it. The runner will get there on its own soon enough.

It also explains why this fails on pull requests that do not touch `package-lock.json` at all, such as #2333, which only bumps a GitHub Action.

### The fix

Approve install scripts for the three native dependencies, which is what `npm install-scripts approve` writes:

```json
"allowScripts": {
  "canvas": true,
  "sqlite3": true,
  "@maplibre/maplibre-gl-native": true
}
```

These are deliberately unpinned. `npm install-scripts approve` defaults to writing `pkg@version` entries, which would go stale and break CI again the next time Dependabot bumps any of the three. Unpinned entries survive version bumps.

Then swap the removed CLI flag for the config it used to set:

```
npm_config_build_from_source=true npm rebuild canvas
```

That keeps canvas building from source rather than pulling a prebuilt binary, which I assume is still wanted given #2015. `prebuild-install` reads `env.npm_config_build_from_source` in `rc.js` and exits non-zero in `bin.js`, which is what makes canvas fall through to `node-gyp rebuild`. Same path as before.

Applied to all six places the old flag appears. Three Dockerfiles are broken now. The other three are the `Rebuild canvas from source` steps in `ci.yml`, `ct.yml` and `release.yml`, which pass today but will break identically once the runner picks up npm 12. `release.yml` is worth fixing ahead of time since that failing takes the publish path down with it.

### Verification

Built locally against `ubuntu:noble` with the NodeSource Node 24 the Dockerfile actually uses, so npm 12.0.2:

- Unmodified master reproduces the `EUNKNOWNCONFIG` failure
- With both changes the full image builds
- All three native modules produce `.node` binaries and load
- canvas is genuinely compiled rather than downloaded, with a `node-gyp` Makefile and object files under `build/`
- The container starts and serves `GET /` and `GET /health` as 200
- Server side rendering works, both a raster tile and a static map return valid PNGs, which exercises maplibre-native and canvas at runtime

### Two things worth flagging separately

`npm_config_build_from_source` now warns that it is an unknown env config and will error in a future major npm. It works today, but the source build will need a different mechanism eventually.

Anyone installing tileserver-gl with npm 12 will hit the same script blocking, since `allowScripts` is project level and does not carry to consumers. That is a separate problem from this pull request but probably worth a look.
