### PR TITLE
fix: never leave a renderer request or pool slot unsettled

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2,6 +2,7 @@
 
 'use strict';
 import os from 'os';
+import { inspect } from 'node:util';
 
 const envSize = parseInt(process.env.UV_THREADPOOL_SIZE, 10);
 process.env.UV_THREADPOOL_SIZE = Math.ceil(
@@ -25,18 +26,63 @@ import { openMbTilesWrapper } from './mbtiles_wrapper.js';
 // Global Error Handlers - Prevent server crashes from unhandled errors
 // ============================================================================
 
+// Keeping the process alive hides the failure unless the log says what broke,
+// so report the stack, any cause chain, and how often this has happened. A
+// repeating count is the signal that something is looping, not misfiring once.
+const survivedErrorCounts = new Map();
+const SURVIVED_ERROR_KEYS_MAX = 500;
+
+/**
+ * Renders a thrown value as text, following up to `depth` levels of `cause`.
+ * @param {unknown} err - The thrown value or rejection reason.
+ * @param {number} [depth] - Remaining cause levels to follow.
+ * @returns {string} A printable description of the error.
+ */
+function describeError(err, depth = 3) {
+  if (!(err instanceof Error)) {
+    return `Non-Error value: ${inspect(err, { depth: 3 })}`;
+  }
+  let text = err.stack || `${err.name}: ${err.message}`;
+  if (err.cause !== undefined && depth > 0) {
+    text += `\nCaused by: ${describeError(err.cause, depth - 1)}`;
+  }
+  return text;
+}
+
+/**
+ * Reports an error the process deliberately survived.
+ * @param {string} kind - The handler that fired.
+ * @param {unknown} err - The thrown value or rejection reason.
+ * @returns {void}
+ */
+function reportSurvivedError(kind, err) {
+  const detail = describeError(err);
+  const key = `${kind} :: ${err instanceof Error ? err.message : detail}`;
+
+  let occurrence = '';
+  if (survivedErrorCounts.has(key)) {
+    const count = survivedErrorCounts.get(key) + 1;
+    survivedErrorCounts.set(key, count);
+    occurrence = ` (occurrence ${count})`;
+  } else if (survivedErrorCounts.size < SURVIVED_ERROR_KEYS_MAX) {
+    // Bounded: distinct messages can carry tile coordinates or URLs, and an
+    // unbounded tally of them would be a leak of its own.
+    survivedErrorCounts.set(key, 1);
+    occurrence = ' (occurrence 1)';
+  }
+
+  console.error(`[${kind}] server continuing after error${occurrence}:`);
+  console.error(detail);
+}
+
 // Prevent unhandled promise rejections from crashing the server
-process.on('unhandledRejection', (reason, promise) => {
-  console.error('Unhandled Promise Rejection at:', promise);
-  console.error('Reason:', reason);
-  // Don't exit - keep server running
+process.on('unhandledRejection', (reason) => {
+  reportSurvivedError('unhandledRejection', reason);
 });
 
 // Prevent uncaught exceptions from crashing the server
 process.on('uncaughtException', (error) => {
-  console.error('Uncaught Exception:', error);
-  console.error('Stack:', error.stack);
-  // Don't exit - keep server running
+  reportSurvivedError('uncaughtException', error);
 });
 
 // ============================================================================

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -67,6 +67,12 @@ const PATH_PATTERN =
 
 const mercator = new SphericalMercator();
 
+// Consecutive failed renders per renderer. A single render error is usually a
+// style or tile problem, but a renderer that keeps failing is itself broken and
+// has to be replaced.
+const rendererFailures = new WeakMap();
+const MAX_CONSECUTIVE_RENDER_FAILURES = 3;
+
 mlgl.on('message', (e) => {
   if (e.severity === 'WARNING' || e.severity === 'ERROR') {
     console.log('mlgl:', e);
@@ -615,10 +621,39 @@ async function respondImage(
       return;
     }
 
+    // Hand the renderer back to the pool exactly once. A renderer that is
+    // neither released nor removed stays in the pool's busy list forever, so the
+    // pool shrinks and a replacement mlgl.Map is built to take its place.
+    let returned = false;
+    const releaseRenderer = () => {
+      if (returned) {
+        return;
+      }
+      returned = true;
+      try {
+        pool.release(renderer);
+      } catch (e) {
+        console.error('Error releasing renderer:', e);
+      }
+    };
+    const discardRenderer = (reason) => {
+      if (returned) {
+        return;
+      }
+      returned = true;
+      console.error(`Discarding renderer: ${reason}`);
+      try {
+        pool.removeBadObject(renderer);
+      } catch (e) {
+        console.error('Error removing bad renderer:', e);
+      }
+    };
+
     if (!renderer) {
       console.error(
         'Renderer is null - likely crashed or failed to initialize',
       );
+      discardRenderer('renderer is null');
       if (!res.headersSent) {
         if (metricsModule) {
           metricsModule.tileErrorsTotal.inc({ type: 'rendered', name: id });
@@ -630,12 +665,7 @@ async function respondImage(
 
     // Validate renderer has required methods (basic health check)
     if (typeof renderer.render !== 'function') {
-      console.error('Renderer is invalid - missing render method');
-      try {
-        pool.removeBadObject(renderer);
-      } catch (e) {
-        console.error('Error removing bad renderer:', e);
-      }
+      discardRenderer('missing render method');
       if (!res.headersSent) {
         if (metricsModule) {
           metricsModule.tileErrorsTotal.inc({ type: 'rendered', name: id });
@@ -670,13 +700,7 @@ async function respondImage(
 
     // Set a timeout for the render operation to detect hung renderers
     const renderTimeout = setTimeout(() => {
-      console.error('Renderer timeout - destroying hung renderer');
-
-      try {
-        pool.removeBadObject(renderer);
-      } catch (e) {
-        console.error('Error removing timed-out renderer:', e);
-      }
+      discardRenderer('render timed out - renderer is hung');
 
       if (!res.headersSent) {
         res.status(503).send('Renderer timeout');
@@ -688,16 +712,23 @@ async function respondImage(
         clearTimeout(renderTimeout);
 
         if (res.headersSent) {
-          // Timeout already fired and sent response, don't process
+          // The timeout already fired and answered the request. It discarded
+          // the renderer, so this is a no-op unless some other path responded.
+          releaseRenderer();
           return;
         }
 
         if (err) {
+          // Keep a renderer that hit a one-off error: discarding on every
+          // failure churns mlgl.Map instances for what is usually a style or
+          // tile problem. Replace it only once it fails repeatedly.
           console.error('Render error:', err);
-          try {
-            pool.removeBadObject(renderer);
-          } catch (e) {
-            console.error('Error removing failed renderer:', e);
+          const failures = (rendererFailures.get(renderer) || 0) + 1;
+          rendererFailures.set(renderer, failures);
+          if (failures >= MAX_CONSECUTIVE_RENDER_FAILURES) {
+            discardRenderer(`${failures} consecutive render failures`);
+          } else {
+            releaseRenderer();
           }
           if (!res.headersSent) {
             if (metricsModule) {
@@ -711,8 +742,8 @@ async function respondImage(
           return;
         }
 
-        // Only release if render was successful
-        pool.release(renderer);
+        rendererFailures.delete(renderer);
+        releaseRenderer();
 
         const image = sharp(data, {
           raw: {
@@ -840,11 +871,7 @@ async function respondImage(
     } catch (error) {
       clearTimeout(renderTimeout);
       console.error('Unexpected error during render:', error);
-      try {
-        pool.removeBadObject(renderer);
-      } catch (e) {
-        console.error('Error removing renderer after error:', e);
-      }
+      discardRenderer('render call threw');
       if (!res.headersSent) {
         if (metricsModule) {
           metricsModule.tileErrorsTotal.inc({ type: 'rendered', name: id });
@@ -1380,149 +1407,226 @@ export const serve_rendered = {
           mode,
           ratio,
           request: async (req, callback) => {
-            const protocol = req.url.split(':')[0];
-            if (verbose >= 3) {
-              console.log('Handling request:', req);
-            }
-            if (protocol === 'sprites') {
-              // eslint-disable-next-line security/detect-object-injection -- protocol is 'sprites', validated above
-              const dir = options.paths[protocol];
-              const file = decodeURIComponent(req.url).substring(
-                protocol.length + 3,
-              );
-              readFile(path.join(dir, file))
-                .then((data) => {
-                  callback(null, { data: data });
-                })
-                .catch((err) => {
-                  callback(err, null);
-                });
-            } else if (protocol === 'fonts') {
-              const parts = req.url.split('/');
-              const fontstack = decodeURIComponent(parts[2]);
-              const range = parts[3].split('.')[0];
-
-              try {
-                const concatenated = await getFontsPbf(
-                  null,
-                  // eslint-disable-next-line security/detect-object-injection -- protocol is 'fonts', validated above
-                  options.paths[protocol],
-                  fontstack,
-                  range,
-                  existingFonts,
-                );
-                callback(null, { data: concatenated });
-              } catch (err) {
-                callback(err, { data: null });
-              }
-            } else if (protocol === 'mbtiles' || protocol === 'pmtiles') {
-              const parts = req.url.split('/');
-              const sourceId = parts[2];
-              // eslint-disable-next-line security/detect-object-injection -- sourceId from internal style source names
-              const source = map.sources[sourceId];
-              // eslint-disable-next-line security/detect-object-injection -- sourceId from internal style source names
-              const sourceType = map.sourceTypes[sourceId];
-              // eslint-disable-next-line security/detect-object-injection -- sourceId from internal style source names
-              const sourceInfo = styleJSON.sources[sourceId];
-
-              const z = parts[3] | 0;
-              const x = parts[4] | 0;
-              const y = parts[5].split('.')[0] | 0;
-              const format = parts[5].split('.')[1];
-
-              const fetchTile = await fetchTileData(
-                source,
-                sourceType,
-                z,
-                x,
-                y,
-              );
-              if (fetchTile == null) {
-                if (verbose >= 2) {
-                  console.log('fetchTile null on %s', req.url);
-                }
-                // eslint-disable-next-line security/detect-object-injection -- sourceId from internal style source names
-                const sparse = map.sparseFlags[sourceId] ?? true;
-                // sparse=true (default) -> return empty callback so MapLibre can overzoom
-                if (sparse) {
-                  callback();
-                  return;
-                }
-                // sparse=false -> 204 (empty tile, no overzoom) - create blank response
-                createEmptyResponse(
-                  sourceInfo.format,
-                  sourceInfo.color,
-                  callback,
-                );
+            // MapLibre Native waits indefinitely for a resource whose callback
+            // never fires, wedging the renderer at 0% CPU until the render timeout
+            // recycles it. Guarantee exactly one call on every path, including throws.
+            let settled = false;
+            const respond = (err, response) => {
+              if (settled) {
                 return;
               }
+              settled = true;
+              callback(err, response);
+            };
 
-              const response = {};
-              response.data = fetchTile.data;
-              let headers = fetchTile.headers;
-
-              if (headers['Last-Modified']) {
-                response.modified = new Date(headers['Last-Modified']);
+            try {
+              const protocol = req.url.split(':')[0];
+              if (verbose >= 3) {
+                console.log('Handling request:', req);
               }
+              if (protocol === 'sprites') {
+                // eslint-disable-next-line security/detect-object-injection -- protocol is 'sprites', validated above
+                const dir = options.paths[protocol];
+                const file = decodeURIComponent(req.url).substring(
+                  protocol.length + 3,
+                );
+                readFile(path.join(dir, file))
+                  .then((data) => {
+                    respond(null, { data: data });
+                  })
+                  .catch((err) => {
+                    respond(err, null);
+                  });
+              } else if (protocol === 'fonts') {
+                const parts = req.url.split('/');
+                const fontstack = decodeURIComponent(parts[2]);
+                const range = parts[3].split('.')[0];
 
-              if (format === 'pbf') {
-                let isGzipped =
-                  response.data
-                    .slice(0, 2)
-                    .indexOf(Buffer.from([0x1f, 0x8b])) === 0;
-                if (isGzipped) {
-                  response.data = await gunzipP(response.data);
-                }
-                if (options.dataDecoratorFunc) {
-                  response.data = options.dataDecoratorFunc(
-                    sourceId,
-                    'data',
-                    response.data,
-                    z,
-                    x,
-                    y,
+                try {
+                  const concatenated = await getFontsPbf(
+                    null,
+                    // eslint-disable-next-line security/detect-object-injection -- protocol is 'fonts', validated above
+                    options.paths[protocol],
+                    fontstack,
+                    range,
+                    existingFonts,
                   );
+                  respond(null, { data: concatenated });
+                } catch (err) {
+                  respond(err, { data: null });
                 }
-              }
+              } else if (protocol === 'mbtiles' || protocol === 'pmtiles') {
+                const parts = req.url.split('/');
+                const sourceId = parts[2];
+                // eslint-disable-next-line security/detect-object-injection -- sourceId from internal style source names
+                const source = map.sources[sourceId];
+                // eslint-disable-next-line security/detect-object-injection -- sourceId from internal style source names
+                const sourceType = map.sourceTypes[sourceId];
+                // eslint-disable-next-line security/detect-object-injection -- sourceId from internal style source names
+                const sourceInfo = styleJSON.sources[sourceId];
 
-              callback(null, response);
-            } else if (protocol === 'http' || protocol === 'https') {
-              const controller = new AbortController();
-              const timeoutMs = (fetchTimeout && Number(fetchTimeout)) || 15000;
-              let timeoutId;
+                const z = parts[3] | 0;
+                const x = parts[4] | 0;
+                const y = parts[5].split('.')[0] | 0;
+                const format = parts[5].split('.')[1];
 
-              try {
-                timeoutId = setTimeout(() => controller.abort(), timeoutMs);
-                const response = await fetch(req.url, {
-                  signal: controller.signal,
-                });
-                clearTimeout(timeoutId);
-
-                // HTTP 204 No Content means "empty tile" - generate a blank tile
-                if (response.status === 204) {
-                  const parts = url.parse(req.url);
-                  const extension = path.extname(parts.pathname).toLowerCase();
-                  // eslint-disable-next-line security/detect-object-injection -- extension is from path.extname, limited set
-                  const format = extensionToFormat[extension] || '';
-                  createEmptyResponse(format, '', callback);
+                const fetchTile = await fetchTileData(
+                  source,
+                  sourceType,
+                  z,
+                  x,
+                  y,
+                );
+                if (fetchTile == null) {
+                  if (verbose >= 2) {
+                    console.log('fetchTile null on %s', req.url);
+                  }
+                  // eslint-disable-next-line security/detect-object-injection -- sourceId from internal style source names
+                  const sparse = map.sparseFlags[sourceId] ?? true;
+                  // sparse=true (default) -> return empty callback so MapLibre can overzoom
+                  if (sparse) {
+                    respond();
+                    return;
+                  }
+                  // sparse=false -> 204 (empty tile, no overzoom) - create blank response
+                  createEmptyResponse(
+                    sourceInfo.format,
+                    sourceInfo.color,
+                    respond,
+                  );
                   return;
                 }
 
-                if (!response.ok) {
-                  if (verbose >= 2) {
-                    console.log(
-                      'fetchTile HTTP %d on %s, %s',
-                      response.status,
-                      req.url,
-                      globalSparse
-                        ? 'allowing overzoom'
-                        : 'creating empty tile',
+                const response = {};
+                response.data = fetchTile.data;
+                let headers = fetchTile.headers;
+
+                if (headers['Last-Modified']) {
+                  response.modified = new Date(headers['Last-Modified']);
+                }
+
+                if (format === 'pbf') {
+                  let isGzipped =
+                    response.data
+                      .slice(0, 2)
+                      .indexOf(Buffer.from([0x1f, 0x8b])) === 0;
+                  if (isGzipped) {
+                    response.data = await gunzipP(response.data);
+                  }
+                  if (options.dataDecoratorFunc) {
+                    response.data = options.dataDecoratorFunc(
+                      sourceId,
+                      'data',
+                      response.data,
+                      z,
+                      x,
+                      y,
+                    );
+                  }
+                }
+
+                respond(null, response);
+              } else if (protocol === 'http' || protocol === 'https') {
+                const controller = new AbortController();
+                const timeoutMs =
+                  (fetchTimeout && Number(fetchTimeout)) || 15000;
+                let timeoutId;
+
+                try {
+                  timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+                  const response = await fetch(req.url, {
+                    signal: controller.signal,
+                  });
+                  clearTimeout(timeoutId);
+
+                  // HTTP 204 No Content means "empty tile" - generate a blank tile
+                  if (response.status === 204) {
+                    const parts = url.parse(req.url);
+                    const extension = path
+                      .extname(parts.pathname)
+                      .toLowerCase();
+                    // eslint-disable-next-line security/detect-object-injection -- extension is from path.extname, limited set
+                    const format = extensionToFormat[extension] || '';
+                    createEmptyResponse(format, '', respond);
+                    return;
+                  }
+
+                  if (!response.ok) {
+                    if (verbose >= 2) {
+                      console.log(
+                        'fetchTile HTTP %d on %s, %s',
+                        response.status,
+                        req.url,
+                        globalSparse
+                          ? 'allowing overzoom'
+                          : 'creating empty tile',
+                      );
+                    }
+
+                    if (globalSparse) {
+                      // sparse=true -> allow overzoom
+                      respond();
+                      return;
+                    }
+
+                    // sparse=false (default) -> create empty tile
+                    const parts = url.parse(req.url);
+                    const extension = path
+                      .extname(parts.pathname)
+                      .toLowerCase();
+                    // eslint-disable-next-line security/detect-object-injection -- extension is from path.extname, limited set
+                    const format = extensionToFormat[extension] || '';
+                    createEmptyResponse(format, '', respond);
+                    return;
+                  }
+
+                  const responseHeaders = response.headers;
+                  const responseData = await response.arrayBuffer();
+                  const parsedResponse = {};
+
+                  if (responseHeaders.get('last-modified')) {
+                    parsedResponse.modified = new Date(
+                      responseHeaders.get('last-modified'),
+                    );
+                  }
+                  if (responseHeaders.get('expires')) {
+                    parsedResponse.expires = new Date(
+                      responseHeaders.get('expires'),
+                    );
+                  }
+                  if (responseHeaders.get('etag')) {
+                    parsedResponse.etag = responseHeaders.get('etag');
+                  }
+
+                  parsedResponse.data = Buffer.from(responseData);
+                  respond(null, parsedResponse);
+                } catch (error) {
+                  // Log DNS failures
+                  if (error.cause?.code === 'ENOTFOUND') {
+                    console.error(
+                      `DNS RESOLUTION FAILED for ${req.url}. ` +
+                        `This domain may be unreachable or misconfigured in your style. ` +
+                        `Consider removing it or fixing the DNS.`,
                     );
                   }
 
+                  // Log timeout
+                  if (error.name === 'AbortError') {
+                    console.error(
+                      `FETCH TIMEOUT for ${req.url}. ` +
+                        `The request took longer than ${timeoutMs} ms to complete.`,
+                    );
+                  }
+
+                  // Log all other errors
+                  console.error(
+                    `Error fetching remote URL ${req.url}:`,
+                    error.message || error,
+                  );
+
                   if (globalSparse) {
                     // sparse=true -> allow overzoom
-                    callback();
+                    respond();
                     return;
                   }
 
@@ -1531,90 +1635,40 @@ export const serve_rendered = {
                   const extension = path.extname(parts.pathname).toLowerCase();
                   // eslint-disable-next-line security/detect-object-injection -- extension is from path.extname, limited set
                   const format = extensionToFormat[extension] || '';
-                  createEmptyResponse(format, '', callback);
-                  return;
+                  createEmptyResponse(format, '', respond);
                 }
+              } else if (protocol === 'file') {
+                const name = decodeURI(req.url).substring(protocol.length + 3);
+                const file = path.join(options.paths['files'], name);
+                if (await existsP(file)) {
+                  const inputFileStats = await fsp.stat(file);
+                  if (!inputFileStats.isFile() || inputFileStats.size === 0) {
+                    throw Error(
+                      `File is not valid: "${req.url}" - resolved to "${file}"`,
+                    );
+                  }
 
-                const responseHeaders = response.headers;
-                const responseData = await response.arrayBuffer();
-                const parsedResponse = {};
-
-                if (responseHeaders.get('last-modified')) {
-                  parsedResponse.modified = new Date(
-                    responseHeaders.get('last-modified'),
-                  );
-                }
-                if (responseHeaders.get('expires')) {
-                  parsedResponse.expires = new Date(
-                    responseHeaders.get('expires'),
-                  );
-                }
-                if (responseHeaders.get('etag')) {
-                  parsedResponse.etag = responseHeaders.get('etag');
-                }
-
-                parsedResponse.data = Buffer.from(responseData);
-                callback(null, parsedResponse);
-              } catch (error) {
-                // Log DNS failures
-                if (error.cause?.code === 'ENOTFOUND') {
-                  console.error(
-                    `DNS RESOLUTION FAILED for ${req.url}. ` +
-                      `This domain may be unreachable or misconfigured in your style. ` +
-                      `Consider removing it or fixing the DNS.`,
-                  );
-                }
-
-                // Log timeout
-                if (error.name === 'AbortError') {
-                  console.error(
-                    `FETCH TIMEOUT for ${req.url}. ` +
-                      `The request took longer than ${timeoutMs} ms to complete.`,
-                  );
-                }
-
-                // Log all other errors
-                console.error(
-                  `Error fetching remote URL ${req.url}:`,
-                  error.message || error,
-                );
-
-                if (globalSparse) {
-                  // sparse=true -> allow overzoom
-                  callback();
-                  return;
-                }
-
-                // sparse=false (default) -> create empty tile
-                const parts = url.parse(req.url);
-                const extension = path.extname(parts.pathname).toLowerCase();
-                // eslint-disable-next-line security/detect-object-injection -- extension is from path.extname, limited set
-                const format = extensionToFormat[extension] || '';
-                createEmptyResponse(format, '', callback);
-              }
-            } else if (protocol === 'file') {
-              const name = decodeURI(req.url).substring(protocol.length + 3);
-              const file = path.join(options.paths['files'], name);
-              if (await existsP(file)) {
-                const inputFileStats = await fsp.stat(file);
-                if (!inputFileStats.isFile() || inputFileStats.size === 0) {
+                  readFile(file)
+                    .then((data) => {
+                      respond(null, { data: data });
+                    })
+                    .catch((err) => {
+                      respond(err, null);
+                    });
+                } else {
                   throw Error(
-                    `File is not valid: "${req.url}" - resolved to "${file}"`,
+                    `File does not exist: "${req.url}" - resolved to "${file}"`,
                   );
                 }
-
-                readFile(file)
-                  .then((data) => {
-                    callback(null, { data: data });
-                  })
-                  .catch((err) => {
-                    callback(err, null);
-                  });
               } else {
-                throw Error(
-                  `File does not exist: "${req.url}" - resolved to "${file}"`,
-                );
+                throw Error(`Unsupported protocol in request: "${req.url}"`);
               }
+            } catch (err) {
+              console.error(
+                `Error handling renderer request for ${req.url}:`,
+                err,
+              );
+              respond(err, null);
             }
           },
         });


### PR DESCRIPTION
The maplibre-native request handler is an async function whose promise the native side discards. The mbtiles/pmtiles branch had no try/catch and the file branch throws outright, so a throw from fetchTileData, gunzipP, an undefined fetchTile.headers, or a missing file rejected without ever calling the callback. An unknown protocol fell through the chain and called nothing at all. MapLibre Native then waits forever for that resource, which wedges the renderer at 0% CPU until the 30s render timeout recycles it.

Before 5.5.0 that rejection reached node's default unhandled-rejection handling and exited the process; main.js now logs and continues, so the failure is silent and the renderer is destroyed and rebuilt instead.

Wrap the handler in try/catch behind a guard that calls the callback exactly once, and close the protocol chain with an explicit error.

Also make the pool lifecycle exactly-once. respondImage had paths that neither released nor removed the renderer, stranding it in the pool's busy list so the pool shrank and a replacement mlgl.Map was built in its place. Route every path through releaseRenderer/discardRenderer, and stop discarding on a single render error - that is usually a style or tile problem, not a broken renderer, and rebuilding a Map for each one churns native memory. A renderer is now replaced after three consecutive failures.

Refs #1984, #2340