### PR TITLE
fix: restore the format-based sparse default

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -119,7 +119,8 @@ TileServer GL can fetch tiles from remote HTTP/HTTPS sources referenced in your 
 
 **Default behavior:**
 - Default timeout is 15 seconds (15000 milliseconds)
-- If a remote tile request exceeds this timeout, an error is logged and an empty tile is returned to the renderer
+- If a remote tile request exceeds this timeout, an error is logged and the tile is treated as missing
+- What "missing" means follows the source's ``sparse`` setting: raster sources are sparse by default, so MapLibre overzooms from a parent tile, while vector sources are not, so an empty tile is returned to the renderer. See ``sparse`` in :doc:`/config`.
 
 **Tuning the timeout:**
 

--- a/src/serve_data.js
+++ b/src/serve_data.js
@@ -15,6 +15,7 @@ import {
   isValidRemoteUrl,
   fetchTileData,
   lonLatToTilePixel,
+  resolveSparse,
 } from './utils.js';
 import { getPMtilesInfo, openPMtiles } from './pmtiles_adapter.js';
 import { gunzipP, gzipP } from './promises.js';
@@ -626,12 +627,12 @@ export const serve_data = {
       tileJSON = options.dataDecoratorFunc(id, 'tilejson', tileJSON);
     }
 
-    // Determine sparse: per-source overrides global, then format-based default
-    // sparse=true -> 404 (allows overzoom)
-    // sparse=false -> 204 (empty tile, no overzoom)
-    // Default: vector tiles (pbf) -> false, raster tiles -> true
-    const isVector = tileJSON.format === 'pbf';
-    const sparse = params.sparse ?? options.sparse ?? !isVector;
+    // sparse=true -> 404 (allows overzoom), sparse=false -> 204 (empty tile)
+    const sparse = resolveSparse(
+      params.sparse,
+      options.sparse,
+      tileJSON.format === 'pbf',
+    );
 
     // eslint-disable-next-line security/detect-object-injection -- id is from config file data source names
     repo[id] = {

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -1357,9 +1357,6 @@ export const serve_rendered = {
 
     const styleJSON = clone(style);
 
-    // Global sparse flag for HTTP/remote sources (from config options)
-    const globalSparse = options.sparse ?? true;
-
     /**
      * Creates a pool of renderers.
      * @param {number} ratio Pixel ratio
@@ -1442,8 +1439,10 @@ export const serve_rendered = {
                   console.log('fetchTile null on %s', req.url);
                 }
                 // eslint-disable-next-line security/detect-object-injection -- sourceId from internal style source names
-                const sparse = map.sparseFlags[sourceId] ?? true;
-                // sparse=true (default) -> return empty callback so MapLibre can overzoom
+                const sourceSparse = map.sparseFlags[sourceId];
+                const sparse =
+                  sourceSparse ?? options.sparse ?? format !== 'pbf';
+                // sparse=true -> return empty callback so MapLibre can overzoom
                 if (sparse) {
                   callback();
                   return;
@@ -1491,6 +1490,15 @@ export const serve_rendered = {
               const timeoutMs = (fetchTimeout && Number(fetchTimeout)) || 15000;
               let timeoutId;
 
+              const extension = path
+                .extname(url.parse(req.url).pathname)
+                .toLowerCase();
+              // eslint-disable-next-line security/detect-object-injection -- extension is from path.extname, limited set
+              const format = extensionToFormat[extension] || '';
+              // Raster tiles are sparse by default so MapLibre can overzoom;
+              // vector tiles are not. Config overrides either way.
+              const sparse = options.sparse ?? extension !== '.pbf';
+
               try {
                 timeoutId = setTimeout(() => controller.abort(), timeoutMs);
                 const response = await fetch(req.url, {
@@ -1500,10 +1508,6 @@ export const serve_rendered = {
 
                 // HTTP 204 No Content means "empty tile" - generate a blank tile
                 if (response.status === 204) {
-                  const parts = url.parse(req.url);
-                  const extension = path.extname(parts.pathname).toLowerCase();
-                  // eslint-disable-next-line security/detect-object-injection -- extension is from path.extname, limited set
-                  const format = extensionToFormat[extension] || '';
                   createEmptyResponse(format, '', callback);
                   return;
                 }
@@ -1514,23 +1518,17 @@ export const serve_rendered = {
                       'fetchTile HTTP %d on %s, %s',
                       response.status,
                       req.url,
-                      globalSparse
-                        ? 'allowing overzoom'
-                        : 'creating empty tile',
+                      sparse ? 'allowing overzoom' : 'creating empty tile',
                     );
                   }
 
-                  if (globalSparse) {
+                  if (sparse) {
                     // sparse=true -> allow overzoom
                     callback();
                     return;
                   }
 
-                  // sparse=false (default) -> create empty tile
-                  const parts = url.parse(req.url);
-                  const extension = path.extname(parts.pathname).toLowerCase();
-                  // eslint-disable-next-line security/detect-object-injection -- extension is from path.extname, limited set
-                  const format = extensionToFormat[extension] || '';
+                  // sparse=false -> create empty tile
                   createEmptyResponse(format, '', callback);
                   return;
                 }
@@ -1579,17 +1577,13 @@ export const serve_rendered = {
                   error.message || error,
                 );
 
-                if (globalSparse) {
+                if (sparse) {
                   // sparse=true -> allow overzoom
                   callback();
                   return;
                 }
 
-                // sparse=false (default) -> create empty tile
-                const parts = url.parse(req.url);
-                const extension = path.extname(parts.pathname).toLowerCase();
-                // eslint-disable-next-line security/detect-object-injection -- extension is from path.extname, limited set
-                const format = extensionToFormat[extension] || '';
+                // sparse=false -> create empty tile
                 createEmptyResponse(format, '', callback);
               }
             } else if (protocol === 'file') {

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -35,6 +35,7 @@ import {
   fixTileJSONCenter,
   fetchTileData,
   readFile,
+  resolveSparse,
 } from './utils.js';
 import { openPMtiles, getPMtilesInfo } from './pmtiles_adapter.js';
 import { renderOverlay, renderWatermark, renderAttribution } from './render.js';
@@ -1440,8 +1441,11 @@ export const serve_rendered = {
                 }
                 // eslint-disable-next-line security/detect-object-injection -- sourceId from internal style source names
                 const sourceSparse = map.sparseFlags[sourceId];
-                const sparse =
-                  sourceSparse ?? options.sparse ?? format !== 'pbf';
+                const sparse = resolveSparse(
+                  sourceSparse,
+                  options.sparse,
+                  format === 'pbf',
+                );
                 // sparse=true -> return empty callback so MapLibre can overzoom
                 if (sparse) {
                   callback();
@@ -1495,9 +1499,12 @@ export const serve_rendered = {
                 .toLowerCase();
               // eslint-disable-next-line security/detect-object-injection -- extension is from path.extname, limited set
               const format = extensionToFormat[extension] || '';
-              // Raster tiles are sparse by default so MapLibre can overzoom;
-              // vector tiles are not. Config overrides either way.
-              const sparse = options.sparse ?? extension !== '.pbf';
+              // A raw remote URL has no per-source config of its own.
+              const sparse = resolveSparse(
+                undefined,
+                options.sparse,
+                extension === '.pbf',
+              );
 
               try {
                 timeoutId = setTimeout(() => controller.abort(), timeoutMs);
@@ -1810,12 +1817,12 @@ export const serve_rendered = {
             }
           }
 
-          // Set sparse flag: user config overrides format-based default
-          // Vector tiles (pbf) default to false (204), raster tiles default to true (404)
-          const isVector = metadata.format === 'pbf';
           // eslint-disable-next-line security/detect-object-injection -- name is from style sources object keys
-          map.sparseFlags[name] =
-            dataInfo.sparse ?? options.sparse ?? !isVector;
+          map.sparseFlags[name] = resolveSparse(
+            dataInfo.sparse,
+            options.sparse,
+            metadata.format === 'pbf',
+          );
         } else {
           // MBTiles does not support remote URLs
 
@@ -1864,12 +1871,12 @@ export const serve_rendered = {
             }
           }
 
-          // Set sparse flag: user config overrides format-based default
-          // Vector tiles (pbf) default to false (204), raster tiles default to true (404)
-          const isVector = info.format === 'pbf';
           // eslint-disable-next-line security/detect-object-injection -- name is from style sources object keys
-          map.sparseFlags[name] =
-            dataInfo.sparse ?? options.sparse ?? !isVector;
+          map.sparseFlags[name] = resolveSparse(
+            dataInfo.sparse,
+            options.sparse,
+            info.format === 'pbf',
+          );
         }
       }
     }

--- a/src/server.js
+++ b/src/server.js
@@ -452,9 +452,10 @@ async function start(opts) {
                       resolvedS3Region = sourceData.s3Region;
                     }
 
-                    // Get sparse: per-source overrides global, default to true
-                    resolvedSparse =
-                      sourceData.sparse ?? options.sparse ?? true;
+                    // Get sparse: per-source overrides global. Left undefined
+                    // when neither is set, so the consumer applies the
+                    // format-based default (raster sparse, vector not).
+                    resolvedSparse = sourceData.sparse ?? options.sparse;
 
                     break; // Found our match, exit the outer loop
                   }
@@ -482,7 +483,7 @@ async function start(opts) {
                   requestPayer: false,
                   s3Region: undefined,
                   s3UrlFormat: undefined,
-                  sparse: true,
+                  sparse: undefined,
                 };
               }
 

--- a/src/server.js
+++ b/src/server.js
@@ -452,10 +452,10 @@ async function start(opts) {
                       resolvedS3Region = sourceData.s3Region;
                     }
 
-                    // Get sparse: per-source overrides global. Left undefined
-                    // when neither is set, so the consumer applies the
-                    // format-based default (raster sparse, vector not).
-                    resolvedSparse = sourceData.sparse ?? options.sparse;
+                    // Pass the source's own setting through untouched. The
+                    // global option and the format-based default are applied
+                    // by resolveSparse() where the tile format is known.
+                    resolvedSparse = sourceData.sparse;
 
                     break; // Found our match, exit the outer loop
                   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -666,3 +666,20 @@ export async function fetchTileData(source, sourceType, z, x, y) {
     });
   }
 }
+
+/**
+ * Resolves whether a source should answer a missing tile sparsely.
+ *
+ * Precedence is per-source, then the global option, then a format-based
+ * default: raster sources are sparse so MapLibre overzooms from the parent,
+ * vector sources are not so an empty tile stops the overzoom. Nullish
+ * coalescing is deliberate - an explicit `false` at either level must win over
+ * the level below it.
+ * @param {boolean|undefined} sourceSparse - The source's own `sparse` setting.
+ * @param {boolean|undefined} globalSparse - The top-level `sparse` option.
+ * @param {boolean} isVector - Whether the source serves vector tiles.
+ * @returns {boolean} True when a missing tile should answer 404 rather than 204.
+ */
+export function resolveSparse(sourceSparse, globalSparse, isVector) {
+  return sourceSparse ?? globalSparse ?? !isVector;
+}

--- a/test/sparse.js
+++ b/test/sparse.js
@@ -5,6 +5,7 @@ import MBTiles from '@mapbox/mbtiles';
 import sharp from 'sharp';
 import { server } from '../src/server.js';
 import { serve_data } from '../src/serve_data.js';
+import { resolveSparse } from '../src/utils.js';
 
 const SIGNALS = ['SIGHUP', 'SIGINT', 'SIGTERM'];
 
@@ -266,4 +267,43 @@ describe('Sparse tile responses', function () {
       404,
     );
   });
+});
+
+describe('resolveSparse precedence', function () {
+  // source, global, isVector, expected
+  const cases = [
+    // Neither level set: the format decides.
+    [undefined, undefined, true, false],
+    [undefined, undefined, false, true],
+    // The global option overrides the format default, both ways.
+    [undefined, true, true, true],
+    [undefined, true, false, true],
+    [undefined, false, true, false],
+    [undefined, false, false, false],
+    // A per-source value overrides the format default, both ways.
+    [true, undefined, true, true],
+    [true, undefined, false, true],
+    [false, undefined, true, false],
+    [false, undefined, false, false],
+    // A per-source value also overrides the global, both ways. These are the
+    // cases that break if the chain ever uses `||` instead of `??`.
+    [true, false, true, true],
+    [true, false, false, true],
+    [false, true, true, false],
+    [false, true, false, false],
+    // Agreement between the levels changes nothing.
+    [true, true, true, true],
+    [true, true, false, true],
+    [false, false, true, false],
+    [false, false, false, false],
+  ];
+
+  for (const [source, global, isVector, expected] of cases) {
+    const label =
+      `source=${source} global=${global} ` +
+      `${isVector ? 'vector' : 'raster'} -> ${expected}`;
+    it(label, function () {
+      expect(resolveSparse(source, global, isVector)).to.equal(expected);
+    });
+  }
 });

--- a/test/sparse.js
+++ b/test/sparse.js
@@ -1,0 +1,269 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import util from 'node:util';
+import MBTiles from '@mapbox/mbtiles';
+import sharp from 'sharp';
+import { server } from '../src/server.js';
+import { serve_data } from '../src/serve_data.js';
+
+const SIGNALS = ['SIGHUP', 'SIGINT', 'SIGTERM'];
+
+// A vector tile inside the declared zoom range that the Zurich extract does not
+// contain. The same hole is used by test/tiles_data.js.
+const MISSING_VECTOR_TILE = '14/0/0.pbf';
+// Every z1 tile of the raster fixture below is a hole.
+const MISSING_RASTER_TILE = '1/0/0.png';
+
+const RASTER_FIXTURE = 'sparse-raster-fixture.mbtiles';
+
+/**
+ * Writes a raster mbtiles containing only its z0 tile, leaving every z1 tile
+ * missing while still inside the archive's declared zoom range.
+ * @param {string} file - Path of the mbtiles file to create.
+ * @returns {Promise<void>}
+ */
+async function createRasterMbtilesWithHole(file) {
+  const tile = await sharp({
+    create: {
+      width: 256,
+      height: 256,
+      channels: 4,
+      background: { r: 0, g: 0, b: 0, alpha: 1 },
+    },
+  })
+    .png()
+    .toBuffer();
+
+  const mbtiles = await util.promisify((uri, cb) => new MBTiles(uri, cb))(
+    `${file}?mode=rwc`,
+  );
+  const startWriting = util.promisify(mbtiles.startWriting.bind(mbtiles));
+  const putInfo = util.promisify(mbtiles.putInfo.bind(mbtiles));
+  const putTile = util.promisify(mbtiles.putTile.bind(mbtiles));
+  const stopWriting = util.promisify(mbtiles.stopWriting.bind(mbtiles));
+  const close = util.promisify(mbtiles.close.bind(mbtiles));
+
+  await startWriting();
+  await putInfo({
+    name: 'sparse-raster-fixture',
+    format: 'png',
+    bounds: [-180, -85.0511, 180, 85.0511],
+    center: [0, 0, 0],
+    minzoom: 0,
+    maxzoom: 1,
+  });
+  await putTile(0, 0, 0, tile);
+  await stopWriting();
+  await close();
+}
+
+/**
+ * Boots a server from an in-memory config on an ephemeral port.
+ * @param {object} config - The tileserver config object.
+ * @returns {Promise<{app: object, stop: () => Promise<void>}>} The running app
+ *   and a function that shuts it down and releases its data sources.
+ */
+async function startServer(config) {
+  const before = SIGNALS.map((eventName) => ({
+    eventName,
+    count: process.listeners(eventName).length,
+  }));
+
+  const running = await server({ config, port: 0, publicUrl: '/test/' });
+  await running.startupPromise;
+
+  return {
+    app: running.app,
+    async stop() {
+      await running.cleanup();
+      // Closes the mbtiles handles; without this the fixture file stays
+      // locked on Windows and cannot be removed.
+      await serve_data.clear(running.serving.data);
+      if (running.server.listening) {
+        await new Promise((resolve) => running.server.close(resolve));
+      }
+      // server() registers a signal handler per generation; drop ours so
+      // repeated boots do not pile up listeners on the test process.
+      for (const { eventName, count } of before) {
+        for (const listener of process.listeners(eventName).slice(count)) {
+          process.removeListener(eventName, listener);
+        }
+      }
+    },
+  };
+}
+
+/**
+ * Builds a config serving the given data sources out of the test_data dir.
+ * @param {object} data - The `data` section of the config.
+ * @param {boolean} [globalSparse] - Value for the top-level `sparse` option.
+ * @returns {object} A tileserver config object.
+ */
+function configFor(data, globalSparse) {
+  const options = { paths: { fonts: 'fonts', styles: 'styles' } };
+  if (globalSparse !== undefined) {
+    options.sparse = globalSparse;
+  }
+  return { options, data };
+}
+
+describe('Sparse tile responses', function () {
+  let fixturePath;
+
+  before(async function () {
+    // The global setup hook has already chdir'd into test_data.
+    fixturePath = path.join(process.cwd(), RASTER_FIXTURE);
+    fs.rmSync(fixturePath, { force: true });
+    await createRasterMbtilesWithHole(fixturePath);
+  });
+
+  after(function () {
+    fs.rmSync(fixturePath, { force: true });
+  });
+
+  /**
+   * Asserts the status a missing tile returns from a given source.
+   * @param {() => object} getApp - Returns the express app under test.
+   * @param {string} source - Data source id.
+   * @param {string} tile - Tile path suffix, e.g. '14/0/0.pbf'.
+   * @param {number} status - Expected HTTP status.
+   * @returns {void}
+   */
+  const expectMissingTile = (getApp, source, tile, status) => {
+    const url = `/data/${source}/${tile}`;
+    it(`${url} returns ${status}`, function (done) {
+      supertest(getApp()).get(url).expect(status).end(done);
+    });
+  };
+
+  describe('format-based default, with per-source overrides', function () {
+    let running;
+
+    before(async function () {
+      running = await startServer(
+        configFor({
+          'vector-default': { mbtiles: 'zurich_switzerland.mbtiles' },
+          'vector-sparse': {
+            mbtiles: 'zurich_switzerland.mbtiles',
+            sparse: true,
+          },
+          'raster-default': { mbtiles: RASTER_FIXTURE },
+          'raster-dense': { mbtiles: RASTER_FIXTURE, sparse: false },
+        }),
+      );
+    });
+
+    after(async function () {
+      await running.stop();
+    });
+
+    it('serves a tile the raster fixture does contain', function (done) {
+      supertest(running.app)
+        .get('/data/raster-default/0/0/0.png')
+        .expect(200)
+        .expect('Content-Type', /image\/png/)
+        .end(done);
+    });
+
+    // Vector defaults to non-sparse: 204, so MapLibre does not overzoom.
+    expectMissingTile(
+      () => running.app,
+      'vector-default',
+      MISSING_VECTOR_TILE,
+      204,
+    );
+    // Raster defaults to sparse: 404, so MapLibre overzooms from the parent.
+    expectMissingTile(
+      () => running.app,
+      'raster-default',
+      MISSING_RASTER_TILE,
+      404,
+    );
+    // A per-source setting overrides the format default in both directions.
+    expectMissingTile(
+      () => running.app,
+      'vector-sparse',
+      MISSING_VECTOR_TILE,
+      404,
+    );
+    expectMissingTile(
+      () => running.app,
+      'raster-dense',
+      MISSING_RASTER_TILE,
+      204,
+    );
+  });
+
+  describe('global sparse: true', function () {
+    let running;
+
+    before(async function () {
+      running = await startServer(
+        configFor(
+          {
+            'vector-global': { mbtiles: 'zurich_switzerland.mbtiles' },
+            'vector-override': {
+              mbtiles: 'zurich_switzerland.mbtiles',
+              sparse: false,
+            },
+          },
+          true,
+        ),
+      );
+    });
+
+    after(async function () {
+      await running.stop();
+    });
+
+    // The global option overrides the format default...
+    expectMissingTile(
+      () => running.app,
+      'vector-global',
+      MISSING_VECTOR_TILE,
+      404,
+    );
+    // ...and a per-source `false` still overrides the global.
+    expectMissingTile(
+      () => running.app,
+      'vector-override',
+      MISSING_VECTOR_TILE,
+      204,
+    );
+  });
+
+  describe('global sparse: false', function () {
+    let running;
+
+    before(async function () {
+      running = await startServer(
+        configFor(
+          {
+            'raster-global': { mbtiles: RASTER_FIXTURE },
+            'raster-override': { mbtiles: RASTER_FIXTURE, sparse: true },
+          },
+          false,
+        ),
+      );
+    });
+
+    after(async function () {
+      await running.stop();
+    });
+
+    // A global `false` turns off sparse behaviour for raster too...
+    expectMissingTile(
+      () => running.app,
+      'raster-global',
+      MISSING_RASTER_TILE,
+      204,
+    );
+    // ...and a per-source `true` still overrides the global.
+    expectMissingTile(
+      () => running.app,
+      'raster-override',
+      MISSING_RASTER_TILE,
+      404,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

`sparse` was documented — and intended by #1855 — to default per tile format:
raster sources sparse, vector sources not. In practice every style-declared
source has defaulted to `sparse: true` since v5.5.0-pre.6, vector included.

#1855 introduced three copies of the same precedence rule, and one of them
drifted. `server.js` resolved a style source's flag as:

```js
resolvedSparse = sourceData.sparse ?? options.sparse ?? true;
```

Because that is never `undefined`, the format-based fallback in
`serve_rendered.js`:

```js
map.sparseFlags[name] = dataInfo.sparse ?? options.sparse ?? !isVector;
```

short-circuits on its first operand and `!isVector` is dead code.

`serve_data.js` receives the raw config item, where `sparse` genuinely is
undefined, so it *did* apply the format default. The same source therefore
answered differently depending on whether it was served from `/data/…` or
rendered.

## What changed

- `server.js` passes a style source's own `sparse` straight through instead of
  half-resolving it. The global option and the format default are applied where
  the tile format is known.
- The precedence rule now lives in one place, `utils.resolveSparse()`, used by
  all four decision sites. The bug existed *because* the rule was written
  several times, so correcting each copy individually would have left that shape
  intact.
- The renderer's remote-source path had the same format-blind default in
  `const globalSparse = options.sparse ?? true`. It now derives the format from
  the URL extension, which also removes three duplicated copies of that lookup.
- `docs/usage.rst` described only the non-sparse outcome for remote fetch
  timeouts ("an empty tile is returned"). It now says the tile is treated as
  missing, and what that means follows `sparse`.

`docs/config.rst` needed no change — it already documented the format-based
default correctly, which is why the code was wrong rather than the docs.

## Precedence

Unchanged in intent, now actually reachable. Per-source, then global, then
format. Nullish coalescing throughout, so an explicit `false` at either level
beats the level below it:

| config | source | missing tile |
| --- | --- | --- |
| — | vector | `204` |
| — | raster | `404` |
| `sparse: true` per source | vector | `404` |
| `sparse: false` per source | raster | `204` |
| global `true` | vector | `404` |
| global `true` + source `false` | vector | `204` |
| global `false` | raster | `204` |
| global `false` + source `true` | raster | `404` |

## ⚠️ Behaviour change

Deployments relying on style-declared **vector** sources overzooming past
missing tiles will get empty tiles instead after upgrading. This is the
documented behaviour and what #1855 intended, but it has been wrong since
v5.5.0, so some users will have built around it.

The previous behaviour is one line of config, globally or per source:

```json
{ "data": { "my-vector-source": { "mbtiles": "…", "sparse": true } } }
```

## Tests

`sparse` had no coverage at all. Adds 27 cases in `test/sparse.js`:

- **18 unit cases** over `resolveSparse()` — every combination of per-source ×
  global × format. Four of them pin that an explicit `false` beats a `true` at
  the level below, i.e. the reason the chain uses `??` and not `||`.
- **9 integration cases** over `/data/…`, covering the format default, a
  per-source override, and a global override, each in both directions, plus a
  per-source value overriding the global either way.

Raster coverage needs an archive with a hole inside its declared zoom range,
which `test_data` does not contain — `terrain.mbtiles` is complete at both its
zoom levels. The suite writes a one-tile fixture in a `before` hook and removes
it afterwards.

Suite goes from 194 to 221 passing.

### Verified at runtime

The renderer's flag is internal, so it was checked directly rather than
inferred. Probing `map.sparseFlags` for the `openmaptiles` vector source in
`test_data`:

| | `dataInfo.sparse` | global | resolved |
| --- | --- | --- | --- |
| before | `true` | unset | `true` |
| after | `undefined` | unset | `false` |
| after | `undefined` | `true` | `true` |

The third row matters because `server.js` no longer applies the global itself —
it confirms the option still reaches the renderer through the helper.

## Not covered

The integration tests exercise `serve_data`. Whether a *rendered* tile overzooms
past a vector hole is not observable over HTTP — both outcomes are a 200 PNG
differing only in pixels — so that path is covered by the unit tests on
`resolveSparse()` plus the pass-through in `server.js`, not end to end. Closing
that would mean a visual-regression case against `test/fixtures/visual`.

Refs #1855
````