### PR TITLE
chore: drop unused host-validation imports from server.js

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -23,10 +23,6 @@ import {
   getPublicUrl,
   isValidHttpUrl,
   isValidRemoteUrl,
-  parseAllowedHosts,
-  isHostAllowed,
-  getCandidateHost,
-  getSafeProtocol,
 } from './utils.js';
 
 import { fileURLToPath } from 'url';


### PR DESCRIPTION
## Summary

`src/server.js` imports `parseAllowedHosts`, `isHostAllowed`, `getCandidateHost`
and `getSafeProtocol` but never uses them. They have been the only eslint
warnings in the repo, and `lint-action` annotates them on every PR that touches
`server.js` — they showed up on #2348, which did not go near them.

## How they went stale

- **#2032** added the Host-header-poisoning mitigation, imported all four into
  `server.js`, and called `getSafeProtocol(req)` there.
- **#2205** moved that logic into `utils.getPublicUrl()` / `fixUrl()` and removed
  the call sites, leaving the imports behind.

## Not a behaviour change

The mitigation is untouched. All four are still called inside `utils.js`
(`getPublicUrl` at L247-249, `fixUrl` at L283-286), and `server.js` still reaches
them via `getPublicUrl()`. None of the four names appears anywhere else in
`server.js` — the import lines were the only references.

Repo-wide eslint warnings go 4 → 0. Test suite unchanged at 221 passing.

Refs #2032, #2205
