### PR TITLE
fix: honour sparse set in archive metadata

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -294,8 +294,14 @@ Here are the available options for each data source:
     * ``true`` - Returns HTTP 404, allowing clients like MapLibre to overzoom and use parent tiles. Use this for terrain or datasets with uneven zoom coverage.
     * ``false`` - Returns HTTP 204 (No Content), signaling an intentionally empty tile and preventing overzoom.
 
-    This can be set globally in the top-level options or per-data-source (per-source overrides global).
-    Default: Depends on tile format - ``false`` for vector tiles (pbf), ``true`` for raster tiles (png, webp, jpg, etc.).
+    Resolved from the first of these that is set, highest priority first:
+
+    1. ``sparse`` on the data source in this config file
+    2. ``sparse`` in the top-level ``options``
+    3. ``sparse`` in the archive's own metadata (the MBTiles ``metadata`` table, or the PMTiles metadata JSON)
+    4. The tile format - ``false`` for vector tiles (pbf), ``true`` for raster tiles (png, webp, jpg, etc.)
+
+    Config outranks archive metadata, so a source that declares the wrong value for your deployment can be corrected without rewriting the file. MBTiles metadata values are text; ``"true"``/``"false"`` and ``"1"``/``"0"`` are both understood, and anything else is ignored rather than guessed at.
 
 ``s3Profile`` (string)
     Specifies the AWS credential profile to use for S3 PMTiles sources. The profile must be defined in your ``~/.aws/credentials`` file.

--- a/src/serve_data.js
+++ b/src/serve_data.js
@@ -15,6 +15,7 @@ import {
   isValidRemoteUrl,
   fetchTileData,
   lonLatToTilePixel,
+  parseOptionalBoolean,
   resolveSparse,
 } from './utils.js';
 import { getPMtilesInfo, openPMtiles } from './pmtiles_adapter.js';
@@ -620,6 +621,13 @@ export const serve_data = {
     delete tileJSON['scheme'];
     tileJSON['tilejson'] = '3.0.0';
 
+    // MBTiles metadata is a table of strings, so a `sparse` row arrives as
+    // "false" - truthy at face value. Take it as a boolean here and drop the
+    // raw key, so nothing downstream (the data decorator, the served TileJSON)
+    // ever sees the unparsed form. The resolved value is put back below.
+    const metadataSparse = parseOptionalBoolean(tileJSON.sparse);
+    delete tileJSON['sparse'];
+
     Object.assign(tileJSON, params.tilejson || {});
     fixTileJSONCenter(tileJSON);
 
@@ -628,11 +636,14 @@ export const serve_data = {
     }
 
     // sparse=true -> 404 (allows overzoom), sparse=false -> 204 (empty tile)
-    const sparse = resolveSparse(
-      params.sparse,
-      options.sparse,
-      tileJSON.format === 'pbf',
-    );
+    const sparse = resolveSparse({
+      perSource: params.sparse,
+      globalOption: options.sparse,
+      metadata: metadataSparse,
+      isVector: tileJSON.format === 'pbf',
+    });
+    // Advertise what the server will actually do, not what the archive claimed.
+    tileJSON.sparse = sparse;
 
     // eslint-disable-next-line security/detect-object-injection -- id is from config file data source names
     repo[id] = {

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -35,6 +35,7 @@ import {
   fixTileJSONCenter,
   fetchTileData,
   readFile,
+  parseOptionalBoolean,
   resolveSparse,
 } from './utils.js';
 import { openPMtiles, getPMtilesInfo } from './pmtiles_adapter.js';
@@ -1441,11 +1442,12 @@ export const serve_rendered = {
                 }
                 // eslint-disable-next-line security/detect-object-injection -- sourceId from internal style source names
                 const sourceSparse = map.sparseFlags[sourceId];
-                const sparse = resolveSparse(
-                  sourceSparse,
-                  options.sparse,
-                  format === 'pbf',
-                );
+                // Metadata was already folded into sparseFlags at load time.
+                const sparse = resolveSparse({
+                  perSource: sourceSparse,
+                  globalOption: options.sparse,
+                  isVector: format === 'pbf',
+                });
                 // sparse=true -> return empty callback so MapLibre can overzoom
                 if (sparse) {
                   callback();
@@ -1499,12 +1501,11 @@ export const serve_rendered = {
                 .toLowerCase();
               // eslint-disable-next-line security/detect-object-injection -- extension is from path.extname, limited set
               const format = extensionToFormat[extension] || '';
-              // A raw remote URL has no per-source config of its own.
-              const sparse = resolveSparse(
-                undefined,
-                options.sparse,
-                extension === '.pbf',
-              );
+              // A raw remote URL has neither per-source config nor metadata.
+              const sparse = resolveSparse({
+                globalOption: options.sparse,
+                isVector: extension === '.pbf',
+              });
 
               try {
                 timeoutId = setTimeout(() => controller.abort(), timeoutMs);
@@ -1803,6 +1804,11 @@ export const serve_rendered = {
             `pmtiles://${name}/{z}/{x}/{y}.${metadata.format || 'pbf'}`,
           ];
           delete source.scheme;
+          // Object.assign copied the archive metadata onto the style source, so
+          // `sparse` is sitting there unparsed - "false" as a string is truthy.
+          // sparseFlags below is the value the request handler reads, so drop
+          // the duplicate here, before the data decorator sees it.
+          delete source.sparse;
 
           if (
             !attributionOverride &&
@@ -1818,11 +1824,12 @@ export const serve_rendered = {
           }
 
           // eslint-disable-next-line security/detect-object-injection -- name is from style sources object keys
-          map.sparseFlags[name] = resolveSparse(
-            dataInfo.sparse,
-            options.sparse,
-            metadata.format === 'pbf',
-          );
+          map.sparseFlags[name] = resolveSparse({
+            perSource: dataInfo.sparse,
+            globalOption: options.sparse,
+            metadata: parseOptionalBoolean(metadata.sparse),
+            isVector: metadata.format === 'pbf',
+          });
         } else {
           // MBTiles does not support remote URLs
 
@@ -1853,6 +1860,11 @@ export const serve_rendered = {
             `mbtiles://${name}/{z}/{x}/{y}.${info.format || 'pbf'}`,
           ];
           delete source.scheme;
+          // Object.assign copied the archive metadata onto the style source, so
+          // `sparse` is sitting there unparsed - "false" as a string is truthy.
+          // sparseFlags below is the value the request handler reads, so drop
+          // the duplicate here, before the data decorator sees it.
+          delete source.sparse;
 
           if (options.dataDecoratorFunc) {
             source = options.dataDecoratorFunc(name, 'tilejson', source);
@@ -1872,11 +1884,12 @@ export const serve_rendered = {
           }
 
           // eslint-disable-next-line security/detect-object-injection -- name is from style sources object keys
-          map.sparseFlags[name] = resolveSparse(
-            dataInfo.sparse,
-            options.sparse,
-            info.format === 'pbf',
-          );
+          map.sparseFlags[name] = resolveSparse({
+            perSource: dataInfo.sparse,
+            globalOption: options.sparse,
+            metadata: parseOptionalBoolean(info.sparse),
+            isVector: info.format === 'pbf',
+          });
         }
       }
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -668,18 +668,52 @@ export async function fetchTileData(source, sourceType, z, x, y) {
 }
 
 /**
+ * Reads a flag that may arrive as a boolean or as text.
+ *
+ * mbtiles metadata is a table of strings, so a `sparse` row reaches us as
+ * `"false"` - truthy if taken at face value. PMTiles metadata is JSON and can
+ * hold a real boolean. Anything unrecognised is treated as absent rather than
+ * guessed at, so a typo falls through to the next level of precedence instead
+ * of silently meaning `true`.
+ * @param {unknown} value - The raw value.
+ * @returns {boolean|undefined} The boolean, or undefined if absent/unrecognised.
+ */
+export function parseOptionalBoolean(value) {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === 'true' || normalized === '1') {
+      return true;
+    }
+    if (normalized === 'false' || normalized === '0') {
+      return false;
+    }
+  }
+  return undefined;
+}
+
+/**
  * Resolves whether a source should answer a missing tile sparsely.
  *
- * Precedence is per-source, then the global option, then a format-based
- * default: raster sources are sparse so MapLibre overzooms from the parent,
- * vector sources are not so an empty tile stops the overzoom. Nullish
- * coalescing is deliberate - an explicit `false` at either level must win over
- * the level below it.
- * @param {boolean|undefined} sourceSparse - The source's own `sparse` setting.
- * @param {boolean|undefined} globalSparse - The top-level `sparse` option.
- * @param {boolean} isVector - Whether the source serves vector tiles.
+ * Precedence, highest first: the per-source config setting, the global config
+ * option, the archive's own metadata, then a format-based default - raster
+ * sources are sparse so MapLibre overzooms from the parent, vector sources are
+ * not so an empty tile stops the overzoom. Config outranks metadata because an
+ * operator can change their config but not always the archive.
+ *
+ * Nullish coalescing is deliberate: an explicit `false` at any level must win
+ * over the level below it. Named arguments, because four booleans in a row is
+ * an argument-order bug waiting to happen and two of the levels are often
+ * absent.
+ * @param {object} levels - The values to resolve between.
+ * @param {boolean} [levels.perSource] - The source's own `sparse` config setting.
+ * @param {boolean} [levels.globalOption] - The top-level `sparse` option.
+ * @param {boolean} [levels.metadata] - `sparse` from the archive's metadata.
+ * @param {boolean} levels.isVector - Whether the source serves vector tiles.
  * @returns {boolean} True when a missing tile should answer 404 rather than 204.
  */
-export function resolveSparse(sourceSparse, globalSparse, isVector) {
-  return sourceSparse ?? globalSparse ?? !isVector;
+export function resolveSparse({ perSource, globalOption, metadata, isVector }) {
+  return perSource ?? globalOption ?? metadata ?? !isVector;
 }

--- a/test/sparse.js
+++ b/test/sparse.js
@@ -5,7 +5,7 @@ import MBTiles from '@mapbox/mbtiles';
 import sharp from 'sharp';
 import { server } from '../src/server.js';
 import { serve_data } from '../src/serve_data.js';
-import { resolveSparse } from '../src/utils.js';
+import { parseOptionalBoolean, resolveSparse } from '../src/utils.js';
 
 const SIGNALS = ['SIGHUP', 'SIGINT', 'SIGTERM'];
 
@@ -16,14 +16,17 @@ const MISSING_VECTOR_TILE = '14/0/0.pbf';
 const MISSING_RASTER_TILE = '1/0/0.png';
 
 const RASTER_FIXTURE = 'sparse-raster-fixture.mbtiles';
+// Same archive, but its own metadata asks not to be sparse.
+const META_FIXTURE = 'sparse-metadata-fixture.mbtiles';
 
 /**
  * Writes a raster mbtiles containing only its z0 tile, leaving every z1 tile
  * missing while still inside the archive's declared zoom range.
  * @param {string} file - Path of the mbtiles file to create.
+ * @param {object} [extraMetadata] - Extra keys to merge into the archive metadata.
  * @returns {Promise<void>}
  */
-async function createRasterMbtilesWithHole(file) {
+async function createRasterMbtilesWithHole(file, extraMetadata = {}) {
   const tile = await sharp({
     create: {
       width: 256,
@@ -52,6 +55,7 @@ async function createRasterMbtilesWithHole(file) {
     center: [0, 0, 0],
     minzoom: 0,
     maxzoom: 1,
+    ...extraMetadata,
   });
   await putTile(0, 0, 0, tile);
   await stopWriting();
@@ -110,16 +114,23 @@ function configFor(data, globalSparse) {
 
 describe('Sparse tile responses', function () {
   let fixturePath;
+  let metaFixturePath;
 
   before(async function () {
     // The global setup hook has already chdir'd into test_data.
     fixturePath = path.join(process.cwd(), RASTER_FIXTURE);
+    metaFixturePath = path.join(process.cwd(), META_FIXTURE);
     fs.rmSync(fixturePath, { force: true });
+    fs.rmSync(metaFixturePath, { force: true });
     await createRasterMbtilesWithHole(fixturePath);
+    // mbtiles metadata is a table of strings, so this round-trips as "false"
+    // and exercises the coercion on the way back out.
+    await createRasterMbtilesWithHole(metaFixturePath, { sparse: false });
   });
 
   after(function () {
     fs.rmSync(fixturePath, { force: true });
+    fs.rmSync(metaFixturePath, { force: true });
   });
 
   /**
@@ -267,43 +278,134 @@ describe('Sparse tile responses', function () {
       404,
     );
   });
+  describe('sparse from archive metadata', function () {
+    let running;
+    let globalRunning;
+
+    before(async function () {
+      running = await startServer(
+        configFor({
+          'meta-dense': { mbtiles: META_FIXTURE },
+          'meta-overridden': { mbtiles: META_FIXTURE, sparse: true },
+        }),
+      );
+      globalRunning = await startServer(
+        configFor({ 'meta-vs-global': { mbtiles: META_FIXTURE } }, true),
+      );
+    });
+
+    after(async function () {
+      await running.stop();
+      await globalRunning.stop();
+    });
+
+    // A raster archive that declares sparse=false in its own metadata.
+    expectMissingTile(
+      () => running.app,
+      'meta-dense',
+      MISSING_RASTER_TILE,
+      204,
+    );
+    // Per-source config outranks the archive.
+    expectMissingTile(
+      () => running.app,
+      'meta-overridden',
+      MISSING_RASTER_TILE,
+      404,
+    );
+    // So does the global option.
+    expectMissingTile(
+      () => globalRunning.app,
+      'meta-vs-global',
+      MISSING_RASTER_TILE,
+      404,
+    );
+
+    it('reports the resolved value in the TileJSON, not the raw metadata', function (done) {
+      supertest(running.app)
+        .get('/data/meta-dense.json')
+        .expect(200)
+        .expect((res) => {
+          expect(res.body.sparse).to.equal(false);
+        })
+        .end(done);
+    });
+  });
 });
 
 describe('resolveSparse precedence', function () {
-  // source, global, isVector, expected
+  // perSource, globalOption, metadata, isVector, expected
   const cases = [
-    // Neither level set: the format decides.
-    [undefined, undefined, true, false],
-    [undefined, undefined, false, true],
+    // Nothing set: the format decides.
+    [undefined, undefined, undefined, true, false],
+    [undefined, undefined, undefined, false, true],
     // The global option overrides the format default, both ways.
-    [undefined, true, true, true],
-    [undefined, true, false, true],
-    [undefined, false, true, false],
-    [undefined, false, false, false],
+    [undefined, true, undefined, true, true],
+    [undefined, false, undefined, false, false],
     // A per-source value overrides the format default, both ways.
-    [true, undefined, true, true],
-    [true, undefined, false, true],
-    [false, undefined, true, false],
-    [false, undefined, false, false],
-    // A per-source value also overrides the global, both ways. These are the
-    // cases that break if the chain ever uses `||` instead of `??`.
-    [true, false, true, true],
-    [true, false, false, true],
-    [false, true, true, false],
-    [false, true, false, false],
-    // Agreement between the levels changes nothing.
-    [true, true, true, true],
-    [true, true, false, true],
-    [false, false, true, false],
-    [false, false, false, false],
+    [true, undefined, undefined, true, true],
+    [false, undefined, undefined, false, false],
+    // A per-source value also overrides the global, both ways. These break if
+    // the chain ever uses `||` instead of `??`.
+    [true, false, undefined, true, true],
+    [false, true, undefined, false, false],
+    // Archive metadata overrides the format default, both ways.
+    [undefined, undefined, true, true, true],
+    [undefined, undefined, false, false, false],
+    // ...but loses to a per-source value, both ways.
+    [true, undefined, false, true, true],
+    [false, undefined, true, false, false],
+    // ...and loses to the global option, both ways.
+    [undefined, true, false, true, true],
+    [undefined, false, true, false, false],
+    // Per-source still wins when all three disagree.
+    [true, false, false, true, true],
+    [false, true, true, false, false],
+    // Agreement between levels changes nothing.
+    [true, true, true, true, true],
+    [false, false, false, false, false],
   ];
 
-  for (const [source, global, isVector, expected] of cases) {
+  for (const [perSource, globalOption, metadata, isVector, expected] of cases) {
     const label =
-      `source=${source} global=${global} ` +
+      `source=${perSource} global=${globalOption} meta=${metadata} ` +
       `${isVector ? 'vector' : 'raster'} -> ${expected}`;
     it(label, function () {
-      expect(resolveSparse(source, global, isVector)).to.equal(expected);
+      expect(
+        resolveSparse({ perSource, globalOption, metadata, isVector }),
+      ).to.equal(expected);
+    });
+  }
+});
+
+describe('parseOptionalBoolean', function () {
+  // mbtiles metadata is a table of strings, so `sparse` arrives as text. Taken
+  // at face value "false" is truthy, which would invert the setting.
+  const cases = [
+    [true, true],
+    [false, false],
+    ['true', true],
+    ['false', false],
+    ['TRUE', true],
+    ['False', false],
+    ['  true  ', true],
+    ['1', true],
+    ['0', false],
+    // Anything unrecognised is absent, so it falls through to the next level
+    // of precedence rather than being guessed at.
+    [undefined, undefined],
+    [null, undefined],
+    ['', undefined],
+    ['yes', undefined],
+    ['maybe', undefined],
+    [1, undefined],
+    [0, undefined],
+    [{}, undefined],
+  ];
+
+  for (const [input, expected] of cases) {
+    it(`${JSON.stringify(input)} -> ${expected}`, function () {
+      expect(parseOptionalBoolean(input)).to.equal(expected);
     });
   }
 });


### PR DESCRIPTION
Before #1855, serve_data read `item.tileJSON.sparse`, and the assignment `tileJSON['sparse'] = params['sparse']` ran before `Object.assign(tileJSON, metadata)` - so a `sparse` key inside an MBTiles or PMTiles archive reached the tile handler. #1855 replaced that with a value derived only from config, and the metadata channel went dead.

`Object.assign` still copies the key onto tileJSON, so the value is still advertised on /data/<id>.json while having no effect on behaviour: an archive declaring sparse=false is reported as false and answers 404 anyway.

resolveSparse() gains a metadata level between the global option and the format default. Config outranks metadata, since an operator can change their config but cannot always rewrite the archive. The TileJSON now reports the resolved value rather than the raw metadata, so what it advertises is what the server does.

MBTiles metadata is a table of strings, so `sparse` arrives as "false" - truthy if taken at face value, which would invert the setting. It is parsed by parseOptionalBoolean(), which accepts booleans, "true"/"false" and "1"/"0", and treats anything else as absent so a typo falls through to the next level rather than silently meaning true.

resolveSparse() also moves to named arguments. Four booleans in a row is an argument-order bug waiting to happen - adding the metadata level positionally silently broke two existing unit cases - and two of the four call sites have nothing to pass for two of the levels.

Refs #1558, #1855