### PR TITLE
fix: data decorator never ran on Windows, or on PMTiles style sources

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -214,6 +214,41 @@ Allows the rendering of inline marker icons or base64 urls.
 For security reasons only allow this if you can control the origins from where the markers are fetched!
 Not used by default.
 
+``dataDecorator``
+-----------------
+
+Path (relative to ``root``) to a JavaScript module whose default export is called to modify tile data and TileJSON on the fly. Not used by default.
+
+The module must be an ES module with a default export. The function is called as ``decorate(id, type, data, z, x, y)`` and **must return the value**, modified or not - returning nothing discards the data.
+
+The function is called synchronously: its return value is used directly and is never awaited, so it cannot do asynchronous work. Returning a promise replaces the tile data with the promise object.
+
+``id``
+  The data source id from the config, or the source name from the style.
+
+``type``
+  Either ``'tilejson'`` or ``'data'``.
+
+``data``
+  For ``'tilejson'``, the TileJSON object served at ``/data/{id}.json``, or a style's local source object. For ``'data'``, a ``Buffer`` of vector tile bytes, already un-gzipped.
+
+``z``, ``x``, ``y``
+  Tile coordinates. Only passed for ``'data'``.
+
+``'data'`` is called for vector (pbf) sources only, both for ``/data/{id}/{z}/{x}/{y}.pbf`` and for the tiles fed to the raster renderer. Raster tiles are never passed through it.
+
+.. code-block:: js
+
+  // decorator.js
+  export default function (id, type, data, z, x, y) {
+    if (type === 'tilejson') {
+      data.attribution = 'Example attribution';
+    }
+    return data;
+  }
+
+Errors loading the module are logged and the server starts without a decorator, so check the startup output if it does not appear to run.
+
 
 ``styles``
 ==========

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -1804,6 +1804,12 @@ export const serve_rendered = {
           ];
           delete source.scheme;
 
+          if (options.dataDecoratorFunc) {
+            source = options.dataDecoratorFunc(name, 'tilejson', source);
+            // eslint-disable-next-line security/detect-object-injection -- name is from style sources object keys
+            styleJSON.sources[name] = source;
+          }
+
           if (
             !attributionOverride &&
             source.attribution &&
@@ -1856,6 +1862,8 @@ export const serve_rendered = {
 
           if (options.dataDecoratorFunc) {
             source = options.dataDecoratorFunc(name, 'tilejson', source);
+            // eslint-disable-next-line security/detect-object-injection -- name is from style sources object keys
+            styleJSON.sources[name] = source;
           }
 
           if (

--- a/src/server.js
+++ b/src/server.js
@@ -25,7 +25,7 @@ import {
   isValidRemoteUrl,
 } from './utils.js';
 
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageJson = JSON.parse(
   fs.readFileSync(__dirname + '/../package.json', 'utf8'),
@@ -190,7 +190,10 @@ async function start(opts) {
     try {
       const dataDecoratorPath = path.resolve(paths.root, options.dataDecorator);
 
-      const module = await import(dataDecoratorPath);
+      // import() needs a file:// URL, not a bare path: on Windows an absolute
+      // path starts with a drive letter and the ESM loader rejects it as an
+      // unknown URL scheme, so the decorator silently never loaded there.
+      const module = await import(pathToFileURL(dataDecoratorPath).href);
       options.dataDecoratorFunc = module.default;
     } catch (e) {
       console.error(`Error loading data decorator: ${e}`);

--- a/test/data_decorator.js
+++ b/test/data_decorator.js
@@ -1,0 +1,84 @@
+import { server } from '../src/server.js';
+
+const SIGNALS = ['SIGHUP', 'SIGINT', 'SIGTERM'];
+
+// Resolved against paths.root, which is the cwd (test_data) when the config is
+// passed as an object rather than a file.
+const DECORATOR = '../test/fixtures/data-decorator.js';
+
+describe('data decorator', function () {
+  let running;
+  let listenerBaseline;
+
+  before(async function () {
+    globalThis.__dataDecoratorCalls = [];
+    listenerBaseline = SIGNALS.map((eventName) => ({
+      eventName,
+      count: process.listeners(eventName).length,
+    }));
+
+    running = await server({
+      config: {
+        options: {
+          paths: { fonts: 'fonts', styles: 'styles' },
+          dataDecorator: DECORATOR,
+        },
+        // The style pulls in the same source through a mbtiles:// url, which
+        // is the path serve_rendered decorates.
+        styles: { 'test-style': { style: 'osm-bright/style.json' } },
+        data: { openmaptiles: { mbtiles: 'zurich_switzerland.mbtiles' } },
+      },
+      port: 0,
+      publicUrl: '/test/',
+    });
+    await running.startupPromise;
+  });
+
+  after(async function () {
+    await running.cleanup();
+    if (running.server.listening) {
+      await new Promise((resolve) => running.server.close(resolve));
+    }
+    for (const { eventName, count } of listenerBaseline) {
+      for (const listener of process.listeners(eventName).slice(count)) {
+        process.removeListener(eventName, listener);
+      }
+    }
+    delete globalThis.__dataDecoratorCalls;
+  });
+
+  // Regression test: the decorator path is absolute, and on Windows that means
+  // it starts with a drive letter. import() rejects that as an unknown URL
+  // scheme, and the failure is swallowed by a try/catch, so the decorator was
+  // never called at all and the server started as though none was configured.
+  it('loads and is called for a configured data source', function () {
+    const calls = globalThis.__dataDecoratorCalls;
+    expect(calls).to.be.an('array');
+    expect(calls.length).to.be.greaterThan(0);
+    expect(calls.map((c) => c.id)).to.include('openmaptiles');
+  });
+
+  it('receives the TileJSON it is meant to decorate', function () {
+    const tilejsonCall = globalThis.__dataDecoratorCalls.find(
+      (c) => c.type === 'tilejson' && c.id === 'openmaptiles',
+    );
+    expect(tilejsonCall, 'no tilejson call recorded').to.not.equal(undefined);
+    expect(tilejsonCall.format).to.equal('pbf');
+  });
+
+  it('is applied to the local sources a style pulls in', function () {
+    // serve_rendered decorates each local source of a style. That call carries
+    // the source object, whose tiles url is the internal mbtiles:// form - the
+    // only thing distinguishing it from the /data tilejson call for the same id.
+    const styleSourceCall = globalThis.__dataDecoratorCalls.find(
+      (c) =>
+        c.type === 'tilejson' &&
+        Array.isArray(c.tiles) &&
+        c.tiles.some((t) => t.startsWith('mbtiles://openmaptiles/')),
+    );
+    expect(styleSourceCall, 'style source was never decorated').to.not.equal(
+      undefined,
+    );
+    expect(styleSourceCall.id).to.equal('openmaptiles');
+  });
+});

--- a/test/fixtures/data-decorator.js
+++ b/test/fixtures/data-decorator.js
@@ -1,0 +1,29 @@
+// Data decorator fixture. Records every call on globalThis so the test can
+// assert what the server handed it, then passes the data through untouched.
+
+/**
+ * Records the call and returns the data unchanged.
+ * @param {string} id - The data source id.
+ * @param {string} type - What is being decorated, e.g. 'tilejson' or 'data'.
+ * @param {unknown} data - The value being decorated.
+ * @returns {unknown} The data, unmodified.
+ */
+export default function decorate(id, type, data) {
+  globalThis.__dataDecoratorCalls = globalThis.__dataDecoratorCalls || [];
+  globalThis.__dataDecoratorCalls.push({
+    id,
+    type,
+    // Snapshot rather than store the live object, which the server mutates
+    // after the decorator returns.
+    sparse: data && data.sparse,
+    sparseType: typeof (data && data.sparse),
+    tiles: data && data.tiles,
+    format: data && data.format,
+  });
+  // Return a *new* object for tilejson, so a caller that only reassigns its
+  // local variable visibly loses the change.
+  if (type === 'tilejson' && data && typeof data === 'object') {
+    return { ...data, decorated: true };
+  }
+  return data;
+}


### PR DESCRIPTION
Three problems with `options.dataDecorator`:

The path is resolved to an absolute path and handed straight to import(). On Windows that starts with a drive letter, which the ESM loader rejects:

  ERR_UNSUPPORTED_ESM_URL_SCHEME ... Received protocol 'c:'

The failure is caught and logged, then startup continues with dataDecoratorFunc undefined, so the decorator silently never ran there at all. Convert with pathToFileURL() before importing.

serve_rendered decorated the local sources a style pulls in, but only in the MBTiles branch - the PMTiles branch had no such call, so PMTiles-backed style sources were never decorated. Add the same call there.

Both call sites assigned the decorator's return value to the loop variable only, leaving styleJSON.sources[name] pointing at the original object. A decorator that returns a new object instead of mutating in place had its result dropped before the style reached the renderer. Store it back.

Adds a fixture decorator that records its calls and returns a new object for tilejson, plus tests that it loads, is handed the TileJSON, and is applied to a style's local sources. The first two fail on Windows without the loader fix.