### PR TITLE
feat: allow the data decorator to be asynchronous

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -221,7 +221,7 @@ Path (relative to ``root``) to a JavaScript module whose default export is calle
 
 The module must be an ES module with a default export. The function is called as ``decorate(id, type, data, z, x, y)`` and **must return the value**, modified or not - returning nothing discards the data.
 
-The function is called synchronously: its return value is used directly and is never awaited, so it cannot do asynchronous work. Returning a promise replaces the tile data with the promise object.
+The function may be ``async``, or return a promise. The return value is awaited, so the decorator can do asynchronous work such as a lookup or a fetch. It is awaited on every call, including once per tile for ``'data'``, so keep it fast or cache inside the module.
 
 ``id``
   The data source id from the config, or the source name from the style.

--- a/src/serve_data.js
+++ b/src/serve_data.js
@@ -141,7 +141,7 @@ export const serve_data = {
 
       if (tileJSONFormat === 'pbf') {
         if (options.dataDecoratorFunc) {
-          data = options.dataDecoratorFunc(
+          data = await options.dataDecoratorFunc(
             req.params.id,
             'data',
             data,
@@ -632,7 +632,7 @@ export const serve_data = {
     fixTileJSONCenter(tileJSON);
 
     if (options.dataDecoratorFunc) {
-      tileJSON = options.dataDecoratorFunc(id, 'tilejson', tileJSON);
+      tileJSON = await options.dataDecoratorFunc(id, 'tilejson', tileJSON);
     }
 
     // sparse=true -> 404 (allows overzoom), sparse=false -> 204 (empty tile)

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -1519,7 +1519,7 @@ export const serve_rendered = {
                     response.data = await gunzipP(response.data);
                   }
                   if (options.dataDecoratorFunc) {
-                    response.data = options.dataDecoratorFunc(
+                    response.data = await options.dataDecoratorFunc(
                       sourceId,
                       'data',
                       response.data,
@@ -1861,7 +1861,7 @@ export const serve_rendered = {
           delete source.sparse;
 
           if (options.dataDecoratorFunc) {
-            source = options.dataDecoratorFunc(name, 'tilejson', source);
+            source = await options.dataDecoratorFunc(name, 'tilejson', source);
             // eslint-disable-next-line security/detect-object-injection -- name is from style sources object keys
             styleJSON.sources[name] = source;
           }
@@ -1923,7 +1923,7 @@ export const serve_rendered = {
           delete source.sparse;
 
           if (options.dataDecoratorFunc) {
-            source = options.dataDecoratorFunc(name, 'tilejson', source);
+            source = await options.dataDecoratorFunc(name, 'tilejson', source);
             // eslint-disable-next-line security/detect-object-injection -- name is from style sources object keys
             styleJSON.sources[name] = source;
           }

--- a/test/data_decorator.js
+++ b/test/data_decorator.js
@@ -66,6 +66,23 @@ describe('data decorator', function () {
     expect(tilejsonCall.format).to.equal('pbf');
   });
 
+  it('uses what the decorator returned, not the object it was handed', function (done) {
+    // The fixture returns a new object rather than mutating in place. Recording
+    // that the decorator ran is not enough - its return value has to be the one
+    // that reaches the response.
+    supertest(running.app)
+      .get('/data/openmaptiles.json')
+      .expect(200)
+      .expect((res) => {
+        expect(
+          res.body.decorated,
+          'decorator return value was dropped',
+        ).to.equal(true);
+        expect(res.body.format, 'TileJSON lost its own fields').to.equal('pbf');
+      })
+      .end(done);
+  });
+
   it('is applied to the local sources a style pulls in', function () {
     // serve_rendered decorates each local source of a style. That call carries
     // the source object, whose tiles url is the internal mbtiles:// form - the
@@ -80,5 +97,60 @@ describe('data decorator', function () {
       undefined,
     );
     expect(styleSourceCall.id).to.equal('openmaptiles');
+  });
+});
+
+describe('async data decorator', function () {
+  let running;
+  let listenerBaseline;
+
+  before(async function () {
+    listenerBaseline = SIGNALS.map((eventName) => ({
+      eventName,
+      count: process.listeners(eventName).length,
+    }));
+    running = await server({
+      config: {
+        options: {
+          paths: { fonts: 'fonts', styles: 'styles' },
+          dataDecorator: '../test/fixtures/data-decorator-async.js',
+        },
+        data: { openmaptiles: { mbtiles: 'zurich_switzerland.mbtiles' } },
+      },
+      port: 0,
+      publicUrl: '/test/',
+    });
+    await running.startupPromise;
+  });
+
+  after(async function () {
+    await running.cleanup();
+    if (running.server.listening) {
+      await new Promise((resolve) => running.server.close(resolve));
+    }
+    for (const { eventName, count } of listenerBaseline) {
+      for (const listener of process.listeners(eventName).slice(count)) {
+        process.removeListener(eventName, listener);
+      }
+    }
+  });
+
+  // Without an await at the call site the decorator's promise is assigned
+  // straight to the TileJSON, which then serves as {tiles: [...]} with every
+  // other field gone - a 200 carrying silently emptied data.
+  it('awaits a decorator that returns a promise', function (done) {
+    supertest(running.app)
+      .get('/data/openmaptiles.json')
+      .expect(200)
+      .expect((res) => {
+        expect(
+          res.body.decoratedAsync,
+          'async decorator was not awaited',
+        ).to.equal(true);
+        expect(res.body.format, 'TileJSON was replaced by a promise').to.equal(
+          'pbf',
+        );
+      })
+      .end(done);
   });
 });

--- a/test/fixtures/data-decorator-async.js
+++ b/test/fixtures/data-decorator-async.js
@@ -1,0 +1,17 @@
+// Async data decorator fixture. Resolves on a later tick before returning, so
+// a caller that does not await it gets a promise rather than the data.
+
+/**
+ * Marks the TileJSON after yielding to the event loop.
+ * @param {string} id - The data source id.
+ * @param {string} type - What is being decorated, e.g. 'tilejson' or 'data'.
+ * @param {unknown} data - The value being decorated.
+ * @returns {Promise<unknown>} The data, marked when it is TileJSON.
+ */
+export default async function decorate(id, type, data) {
+  await new Promise((resolve) => setTimeout(resolve, 1));
+  if (type === 'tilejson' && data && typeof data === 'object') {
+    return { ...data, decoratedAsync: true };
+  }
+  return data;
+}


### PR DESCRIPTION
The decorator's return value was used directly and never awaited, so it had to be synchronous. An async one did not fail loudly: the promise was assigned straight to the TileJSON, which then served as {tiles: [...]} with format, attribution and everything else gone - a 200 carrying silently emptied data.

All five call sites are already inside async functions, so this is an await at each. Awaiting a value that is not a promise yields the value, so existing synchronous decorators are unaffected.

Also adds the assertion the earlier decorator tests were missing. They checked what the decorator recorded, not what it returned, so they passed even with the return value dropped - swapping the fixture to async did not fail a single one of them. There are now two tests that read the decorator's output back off the response: one for a plain object, one for a promise. The async one fails without the awaits.