### PR TITLE
Fix POST static map option parsing

### DIFF
--- a/docs/endpoints.rst
+++ b/docs/endpoints.rst
@@ -89,6 +89,8 @@ Static images
 * All the static image endpoints support parameters passing using POST with a JSON body:
 
   * e.g. ``{"path": ["10,10|20,20", "10,20|20,10"]}`` is the equivalent of ``?path=10,10|20,20&path=10,20|20,10``
+  * multi-word parameters may use either their query spelling or camelCase (e.g. ``linejoin`` or ``lineJoin``)
+  * ``null`` values are ignored, so optional fields emitted by JSON serializers do not override query parameters
 
 * You can also use (experimental) ``/styles/{id}/static/raw/...`` endpoints with raw spherical mercator coordinates (EPSG:3857) instead of WGS84.
 

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -171,9 +171,18 @@ const ALLOW_STATIC_PARAMS = new Set([
   'borderwidth',
 ]);
 
+const STATIC_PARAM_ALIASES = new Map([
+  ['latLng', 'latlng'],
+  ['maxZoom', 'maxzoom'],
+  ['lineCap', 'linecap'],
+  ['lineJoin', 'linejoin'],
+  ['borderWidth', 'borderwidth'],
+]);
+
 /**
  * Merges query and body into a null-prototype object.
- * Accumulates multiple values for the same key into arrays for a lossless merge.
+ * Normalizes JSON-style aliases and accumulates multiple non-null values for
+ * the same key into arrays for a lossless merge.
  * @param {object} query Request query parameters.
  * @param {object} body Request body parameters.
  * @returns {object} The merged parameters.
@@ -186,7 +195,8 @@ export function getSecureMergedParams(query, body) {
     if (typeof source !== 'object' || Array.isArray(source))
       throw new Error(`Invalid data.`);
 
-    for (const [key, value] of Object.entries(source)) {
+    for (const [sourceKey, value] of Object.entries(source)) {
+      const key = STATIC_PARAM_ALIASES.get(sourceKey) ?? sourceKey;
       if (!ALLOW_STATIC_PARAMS.has(key)) {
         continue;
       }
@@ -202,12 +212,20 @@ export function getSecureMergedParams(query, body) {
         );
 
       const ensureArray = (v) => (Array.isArray(v) ? v : [v]);
+      const values = ensureArray(value).filter((item) => item !== null);
+      if (values.length === 0) {
+        continue;
+      }
+      const normalizedValue = Array.isArray(value) ? values : values[0];
+
       if (key in result) {
         // eslint-disable-next-line security/detect-object-injection -- result is a null-prototype object; key is from validated source
-        result[key] = ensureArray(result[key]).concat(ensureArray(value));
+        result[key] = ensureArray(result[key]).concat(
+          ensureArray(normalizedValue),
+        );
       } else {
         // eslint-disable-next-line security/detect-object-injection -- result is a null-prototype object; key is from validated source
-        result[key] = value;
+        result[key] = normalizedValue;
       }
     }
   };

--- a/test/static.js
+++ b/test/static.js
@@ -251,10 +251,8 @@ describe('Static endpoints', function () {
 
       it('POST applies JSON-style path option names', async function () {
         const path = '8.531,47.379|8.5375,47.385|8.544,47.379';
-        const fixedViewPath =
-          '/styles/' + prefix + '/static/8.5375,47.379,12/256x256.png';
         const expected = await supertest(app)
-          .get(fixedViewPath)
+          .get(staticAutoPath)
           .query({
             path,
             width: 30,
@@ -265,7 +263,7 @@ describe('Static endpoints', function () {
           .expect('Content-Type', /image\/png/);
 
         const actual = await supertest(app)
-          .post(fixedViewPath)
+          .post(staticAutoPath)
           .send({
             path,
             width: 30,
@@ -280,8 +278,6 @@ describe('Static endpoints', function () {
 
       it('POST preserves query options when matching body fields are null', async function () {
         const path = '8.531,47.379|8.5375,47.385|8.544,47.379';
-        const requestPath =
-          '/styles/' + prefix + '/static/8.5375,47.379,12/256x256.png';
         const query = {
           border: 'white',
           borderwidth: 5,
@@ -290,14 +286,14 @@ describe('Static endpoints', function () {
           width: 10,
         };
         const expected = await supertest(app)
-          .post(requestPath)
+          .post(staticAutoPath)
           .query(query)
           .send({ path })
           .expect(200)
           .expect('Content-Type', /image\/png/);
 
         const actual = await supertest(app)
-          .post(requestPath)
+          .post(staticAutoPath)
           .query(query)
           .send({
             path,

--- a/test/static.js
+++ b/test/static.js
@@ -248,6 +248,69 @@ describe('Static endpoints', function () {
           .expect('Content-Type', /image\/png/)
           .end(done);
       });
+
+      it('POST applies JSON-style path option names', async function () {
+        const path = '8.531,47.379|8.5375,47.385|8.544,47.379';
+        const fixedViewPath =
+          '/styles/' + prefix + '/static/8.5375,47.379,12/256x256.png';
+        const expected = await supertest(app)
+          .get(fixedViewPath)
+          .query({
+            path,
+            width: 30,
+            linecap: 'round',
+            linejoin: 'bevel',
+          })
+          .expect(200)
+          .expect('Content-Type', /image\/png/);
+
+        const actual = await supertest(app)
+          .post(fixedViewPath)
+          .send({
+            path,
+            width: 30,
+            lineCap: 'round',
+            lineJoin: 'bevel',
+          })
+          .expect(200)
+          .expect('Content-Type', /image\/png/);
+
+        assert.deepStrictEqual(actual.body, expected.body);
+      });
+
+      it('POST preserves query options when matching body fields are null', async function () {
+        const path = '8.531,47.379|8.5375,47.385|8.544,47.379';
+        const requestPath =
+          '/styles/' + prefix + '/static/8.5375,47.379,12/256x256.png';
+        const query = {
+          border: 'white',
+          borderwidth: 5,
+          linecap: 'round',
+          linejoin: 'round',
+          width: 10,
+        };
+        const expected = await supertest(app)
+          .post(requestPath)
+          .query(query)
+          .send({ path })
+          .expect(200)
+          .expect('Content-Type', /image\/png/);
+
+        const actual = await supertest(app)
+          .post(requestPath)
+          .query(query)
+          .send({
+            path,
+            border: null,
+            borderWidth: null,
+            lineCap: null,
+            lineJoin: null,
+          })
+          .expect(200)
+          .expect('Content-Type', /image\/png/);
+
+        assert.deepStrictEqual(actual.body, expected.body);
+      });
     });
 
     describe('invalid requests return 4xx', function () {
@@ -375,6 +438,26 @@ describe('Static endpoints', function () {
       const result = getSecureMergedParams(query, body);
 
       assert.deepStrictEqual(result.latlng, ['', '']);
+    });
+
+    it('should normalize JSON-style names and ignore null body values', () => {
+      const query = { border: 'white' };
+      const body = {
+        lineCap: 'round',
+        lineJoin: 'bevel',
+        border: null,
+        borderWidth: 5,
+        latLng: true,
+        maxZoom: 12,
+      };
+      const result = getSecureMergedParams(query, body);
+
+      assert.strictEqual(result.linecap, 'round');
+      assert.strictEqual(result.linejoin, 'bevel');
+      assert.strictEqual(result.border, 'white');
+      assert.strictEqual(result.borderwidth, 5);
+      assert.strictEqual(result.latlng, true);
+      assert.strictEqual(result.maxzoom, 12);
     });
 
     it('should throw 400 error on nested objects (Deep Object vulnerability)', () => {


### PR DESCRIPTION
Fixes #2201.

POST JSON bodies can contain null optional fields. The merge treated those as real duplicate values, turning a query value such as border=white into an array and producing the reported invalid color warning. This change ignores nulls and normalizes the usual camelCase spellings of multi-word JSON options before the existing allowlist and merge logic run.

The regression tests compare the rendered PNGs, covering both lineCap/lineJoin from the body and query options alongside null body fields. Existing repeated path and marker behavior remains unchanged.

Validation:
- npm run lint:js
- npm run lint:yml
- npx mocha test/setup.js test/static.js --timeout 10000 --exit (64 passing)
- npm test (249 passing; the existing static-bearing-pitch fixture is 131 pixels over a 100-pixel threshold on macOS arm64, identically on upstream/master)